### PR TITLE
Update quickstart.md

### DIFF
--- a/versioned_docs/version-0.5/quickstart.md
+++ b/versioned_docs/version-0.5/quickstart.md
@@ -15,9 +15,9 @@ Install the Fleet Helm charts (there's two because we separate out CRDs for ulti
 
 ```shell
 helm -n cattle-fleet-system install --create-namespace --wait \
-    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-v0.5.0-rc2.tgz
+    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-0.5.0-rc2.tgz
 helm -n cattle-fleet-system install --create-namespace --wait \
-    fleet https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-v0.5.0-rc2.tgz
+    fleet https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-0.5.0-rc2.tgz
 ```
 
 ## Add a Git Repo to watch


### PR DESCRIPTION
A typo in version number, this ends up with: 

```
╰─$ helm -n cattle-fleet-system install --create-namespace --wait \
    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-v0.5.0-rc2.tgz
helm -n cattle-fleet-system install --create-namespace --wait \
    fleet https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-v0.5.0-rc2.tgz

Error: INSTALLATION FAILED: failed to download "https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-v0.5.0-rc2.tgz"
Error: INSTALLATION FAILED: failed to download "https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-v0.5.0-rc2.tgz"
```

Instead of: 

```
╰─$ helm -n cattle-fleet-system install --create-namespace --wait \
    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-0.5.0-rc2.tgz
helm -n cattle-fleet-system install --create-namespace --wait \
    fleet https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-0.5.0-rc2.tgz

NAME: fleet-crd
LAST DEPLOYED: Tue Nov  8 13:25:52 2022
NAMESPACE: cattle-fleet-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NAME: fleet
LAST DEPLOYED: Tue Nov  8 13:26:02 2022
NAMESPACE: cattle-fleet-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```