### PR TITLE
Update helm chart url to stable version 

### DIFF
--- a/docs/agent-initiated.md
+++ b/docs/agent-initiated.md
@@ -68,7 +68,7 @@ helm -n cattle-fleet-system install --create-namespace --wait \
     --values values.yaml \
     --set apiServerCA=${API_SERVER_CA} \
     --set apiServerURL=${API_SERVER_URL} \
-    fleet-agent https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-agent-0.5.0-rc2.tgz
+    fleet-agent https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-agent-0.5.0.tgz
 ```
 
 The agent should now be deployed.  You can check that status of the fleet pods by running the below commands.
@@ -147,7 +147,7 @@ Finally, install the agent using Helm.
 helm -n cattle-fleet-system install --create-namespace --wait \
     --set clientID="${CLUSTER_CLIENT_ID}" \
     --values values.yaml \
-    fleet-agent https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-agent-v0.5.0-rc2.tgz
+    fleet-agent https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-agent-v0.5.0.tgz
 ```
 
 The agent should now be deployed.  You can check that status of the fleet pods by running the below commands.

--- a/docs/multi-cluster-install.md
+++ b/docs/multi-cluster-install.md
@@ -135,7 +135,7 @@ Helm charts.
 
 First install the Fleet CustomResourcesDefintions.
 ```shell
-helm -n cattle-fleet-system install --create-namespace --wait fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-0.5.0-rc2.tgz
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-crd-0.5.0.tgz
 ```
 
 Second install the Fleet controllers.
@@ -143,7 +143,7 @@ Second install the Fleet controllers.
 helm -n cattle-fleet-system install --create-namespace --wait \
     --set apiServerURL="${API_SERVER_URL}" \
     --set-file apiServerCA="${API_SERVER_CA}" \
-    fleet https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-0.5.0-rc2.tgz
+    fleet https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-0.5.0.tgz
 ```
 
 Fleet should be ready to use. You can check the status of the Fleet controller pods by running the below commands.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,9 +15,9 @@ Install the Fleet Helm charts (there's two because we separate out CRDs for ulti
 
 ```shell
 helm -n cattle-fleet-system install --create-namespace --wait \
-    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-v0.5.0-rc2.tgz
+    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-crd-v0.5.0.tgz
 helm -n cattle-fleet-system install --create-namespace --wait \
-    fleet https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-v0.5.0-rc2.tgz
+    fleet https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-v0.5.0.tgz
 ```
 
 ## Add a Git Repo to watch

--- a/docs/single-cluster-install.md
+++ b/docs/single-cluster-install.md
@@ -37,13 +37,13 @@ Install the following two Helm charts.
 First install the Fleet CustomResourcesDefintions.
 ```shell
 helm -n cattle-fleet-system install --create-namespace --wait \
-    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-0.5.0-rc2.tgz
+    fleet-crd https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-crd-0.5.0.tgz
 ```
 
 Second install the Fleet controllers.
 ```shell
 helm -n cattle-fleet-system install --create-namespace --wait \
-    fleet https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-0.5.0-rc2.tgz
+    fleet https://github.com/rancher/fleet/releases/download/v0.5.0/fleet-0.5.0.tgz
 ```
 
 Fleet should be ready to use now for single cluster. You can check the status of the Fleet controller pods by


### PR DESCRIPTION
The rc2 url version no longer works -> [Doc page with helm command ](https://fleet.rancher.io/single-cluster-install)

Error message:
```
Error: INSTALLATION FAILED: failed to download "https://github.com/rancher/fleet/releases/download/v0.5.0-rc2/fleet-crd-0.5.0-rc2.tgz"
```

This pull request fix .tgz urls