### PR TITLE
API_SERVER_CA points to a file

### DIFF
--- a/versioned_docs/version-0.5/agent-initiated.md
+++ b/versioned_docs/version-0.5/agent-initiated.md
@@ -69,7 +69,7 @@ Finally, install the agent using Helm.
 {`helm -n cattle-fleet-system install --create-namespace --wait \\
     $\{CLUSTER_LABELS} \\
     --values values.yaml \\
-    --set apiServerCA=$\{API_SERVER_CA} \\
+    --set-file apiServerCA=$\{API_SERVER_CA} \\
     --set apiServerURL=$\{API_SERVER_URL} \\
     fleet-agent`} {versions["v0.5"].fleetAgent}
 </CodeBlock>


### PR DESCRIPTION
Other pages, such as https://fleet.rancher.io/multi-cluster-install#api-server-url-and-ca-certificate point to `API_SERVER_CA` as a file rather than as the `BEGIN_CERTIFICATE` block.