### PR TITLE
Update dependsOn docs

### DIFF
--- a/docs/gitrepo-structure.md
+++ b/docs/gitrepo-structure.md
@@ -67,6 +67,11 @@ defaultNamespace: default
 # Default: ""
 namespace: default
 
+# Optional map of labels, that are set at the bundle and can be used in a 
+# dependsOn.bundleSelector
+labels:
+  key: value
+
 kustomize:
   # Use a custom folder for kustomize resources. This folder must contain
   # a kustomization.yaml file.
@@ -221,6 +226,10 @@ dependsOn:
   # Format: <GITREPO-NAME>-<BUNDLE_PATH> with all path separators replaced by "-"
   # Example: GitRepo name "one", Bundle path "/multi-cluster/hello-world" => "one-multi-cluster-hello-world"
   - name: one-multi-cluster-hello-world
+  # Select bundles to depend on based on their label.
+  - bundleSelector:
+      matchLabels:
+        app: weak-monkey
 ```
 
 ### Private Helm Repositories


### PR DESCRIPTION
This adds the missing bundleSelector field and shows how you can configure labels in a bundle.

The feature was added in https://github.com/rancher/fleet/pull/552. There was a docs PR https://github.com/rancher/fleet/pull/574, but this was never merged.