### PR TITLE
Add helmRepoUrlRegex to the GitRepo docs

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -67,6 +67,11 @@ spec:
   # this gitrepo. See section below for more information.
   #
   # helmSecretName: my-helm-secret
+  # 
+  # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression. 
+  # Credentials will always be used if it is empty or not provided
+  # 
+  # helmRepoUrlRegex: https://charts.rancher.io/*
   #
   # To add additional ca-bundle for self-signed certs, caBundle can be
   # filled with base64 encoded pem data. For example:


### PR DESCRIPTION
Explains the new `helmRepoUrlRegex` field added in https://github.com/rancher/fleet/pull/1234