### PR TITLE
Fix pollingInterval description

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -98,8 +98,10 @@ spec:
   # is 15 seconds.
   # Setting this to zero does not disable polling. It results in a 15s
   # interval, too.
+  # As checking a git repo incurs a CPU cost, raising this value can help
+  # lowering fleetcontroller's CPU usage if tens of git repos are used or more
   #
-  # pollingInterval: 15
+  # pollingInterval: 15s
 
   # Paused  causes changes in Git to not be propagated down to the clusters but
   # instead mark resources as OutOfSync

--- a/versioned_docs/version-0.4/gitrepo-add.md
+++ b/versioned_docs/version-0.4/gitrepo-add.md
@@ -93,8 +93,10 @@ spec:
   # is 15 seconds.
   # Setting this to zero does not disable polling. It results in a 15s
   # interval, too.
+  # As checking a git repo incurs a CPU cost, raising this value can help
+  # lowering fleetcontroller's CPU usage if tens of git repos are used or more
   #
-  # pollingInterval: 15
+  # pollingInterval: 15s
 
   # Paused  causes changes in Git to not be propagated down to the clusters but
   # instead mark resources as OutOfSync

--- a/versioned_docs/version-0.5/gitrepo-add.md
+++ b/versioned_docs/version-0.5/gitrepo-add.md
@@ -93,8 +93,10 @@ spec:
   # is 15 seconds.
   # Setting this to zero does not disable polling. It results in a 15s
   # interval, too.
+  # As checking a git repo incurs a CPU cost, raising this value can help
+  # lowering fleetcontroller's CPU usage if tens of git repos are used or more
   #
-  # pollingInterval: 15
+  # pollingInterval: 15s
 
   # Paused  causes changes in Git to not be propagated down to the clusters but
   # instead mark resources as OutOfSync


### PR DESCRIPTION
`pollingInterval` is a duration, so it expects a string with a unit of measure rather than an integer.

I also took the liberty to add a performance-related note.

All of this came up investigating the following case: https://jira.suse.com/browse/SURE-3613?focusedCommentId=1246937&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1246937

Supersedes #49 