### PR TITLE
Bump deprecated Node.js actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main docs repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Docusaurus
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: yarn


### PR DESCRIPTION
The following warning is found in the Summary tab of each run of an action using Node.js 12. E.g. https://github.com/rancher/fleet-docs/actions/runs/5080556447.

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.