### PR TITLE
Remove instructions to move clusters

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -19,14 +19,6 @@ Git repos are added to the Fleet manager using the `GitRepo` custom resource typ
 - `Fleet-default` will contain all the downstream clusters that are already registered through Rancher.
 - `Fleet-local` will contain the local cluster by default.
 
-Users can create new workspaces and move clusters across workspaces. An example of a special case might be including the local cluster in the `GitRepo` payload for config maps and secrets (no active deployments or payloads).
-
-:::warning Local Cluster
-
-While it's possible to move clusters out of either workspace, we recommend that you keep the local cluster in `fleet-local`.
-
-:::
-
 If you are using Fleet in a [single cluster](./concepts.md) style, the namespace will always be **fleet-local**. Check [here](https://fleet.rancher.io/namespaces/#fleet-local) for more on the `fleet-local` namespace.
 
 For a [multi-cluster](./concepts.md) style, please ensure you use the correct repo that will map to the right target clusters.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -232,7 +232,11 @@ You can force a redeployment of an agent for a given cluster by setting `redeplo
 kubectl patch clusters.fleet.cattle.io -n fleet-local local --type=json -p '[{"op": "add", "path": "/spec/redeployAgentGeneration", "value": -1}]'
 ```
 
-
 ### Nested GitRepo CRs
 
 Managing Fleet within Fleet (nested `GitRepo` usage) is not currently supported. We will update the documentation if support becomes available.
+
+### Migrate the local cluster to the Fleet default cluster workspace?
+
+Users can create new workspaces and move clusters across workspaces.
+It's currently not possible to move the local cluster from `fleet-local` to another workspace.

--- a/versioned_docs/version-0.5/gitrepo-add.md
+++ b/versioned_docs/version-0.5/gitrepo-add.md
@@ -6,14 +6,6 @@ Git repos are added to the Fleet manager using the `GitRepo` custom resource typ
 - `Fleet-default` will contain all the downstream clusters that are already registered through Rancher.
 - `Fleet-local` will contain the local cluster by default.
 
-Users can create new workspaces and move clusters across workspaces. An example of a special case might be including the local cluster in the `GitRepo` payload for config maps and secrets (no active deployments or payloads).
-
-:::warning
-
-While it's possible to move clusters out of either workspace, we recommend that you keep the local cluster in `fleet-local`.
-
-:::
-
 If you are using Fleet in a [single cluster](./concepts.md) style, the namespace will always be **fleet-local**. Check [here](https://fleet.rancher.io/namespaces/#fleet-local) for more on the `fleet-local` namespace.
 
 For a [multi-cluster](./concepts.md) style, please ensure you use the correct repo that will map to the right target clusters.

--- a/versioned_docs/version-0.5/namespaces.md
+++ b/versioned_docs/version-0.5/namespaces.md
@@ -29,8 +29,6 @@ When fleet is installed the `fleet-local` namespace is created along with one `C
 automatically target the `local` `Cluster`.  The `local` `Cluster` refers to the cluster the Fleet manager is running
 on.
 
-**Note:** If you would like to migrate your cluster from `fleet-local` to `default`, please see this [documentation](./troubleshooting.md#migrate-the-local-cluster-to-the-fleet-default-cluster).
-
 ### cattle-fleet-system
 
 The Fleet controller and Fleet agent run in this namespace. All service accounts referenced by `GitRepos` are expected

--- a/versioned_docs/version-0.5/troubleshooting.md
+++ b/versioned_docs/version-0.5/troubleshooting.md
@@ -67,17 +67,6 @@ NAME                                READY   STATUS    RESTARTS   AGE
 fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ```
 
-### Migrate the local cluster to the Fleet default cluster?
-
-For users who want to deploy to the local cluster as well, they may move the cluster from `fleet-local` to `fleet-default` in the Rancher UI as follows:
-
-- To get to Fleet in Rancher, click ☰ > Continuous Delivery.
-- Under the **Clusters** menu, select the **local** cluster by checking the box to the left.
-- Select **Assign to** from the tabs above the cluster.
-- Select **`fleet-default`** from the **Assign Cluster To** dropdown.
-
-**Result**: The cluster will be migrated to `fleet-default`.
-
 ### Enable debug logging for `fleet-controller` and `fleet-agent`?
 
 Available in Rancher v2.6.3 (Fleet v0.3.8), the ability to enable debug logging has been added.
@@ -224,3 +213,8 @@ Error opening a gzip reader for /tmp/getter154967024/archive: gzip: invalid head
 ```
 
 ... the content of the helm chart is incorrect. Manually download the chart to your local machine and check the content.
+
+### Migrate the local cluster to the Fleet default cluster workspace?
+
+Users can create new workspaces and move clusters across workspaces.
+It's currently not possible to move the local cluster from `fleet-local` to another workspace.

--- a/versioned_docs/version-0.6/namespaces.md
+++ b/versioned_docs/version-0.6/namespaces.md
@@ -19,18 +19,9 @@ Git repos are added to the Fleet manager using the `GitRepo` custom resource typ
 - `Fleet-default` will contain all the downstream clusters that are already registered through Rancher.
 - `Fleet-local` will contain the local cluster by default.
 
-Users can create new workspaces and move clusters across workspaces. An example of a special case might be including the local cluster in the `GitRepo` payload for config maps and secrets (no active deployments or payloads).
-
-:::warning Local Cluster
-
-While it's possible to move clusters out of either workspace, we recommend that you keep the local cluster in `fleet-local`.
-
-:::
-
 If you are using Fleet in a [single cluster](./concepts.md) style, the namespace will always be **fleet-local**. Check [here](https://fleet.rancher.io/namespaces/#fleet-local) for more on the `fleet-local` namespace.
 
 For a [multi-cluster](./concepts.md) style, please ensure you use the correct repo that will map to the right target clusters.
-
 
 ## Namespace Creation Behavior in Bundles
 

--- a/versioned_docs/version-0.6/troubleshooting.md
+++ b/versioned_docs/version-0.6/troubleshooting.md
@@ -67,23 +67,12 @@ NAME                                READY   STATUS    RESTARTS   AGE
 fleet-controller-64f49d756b-n57wq   1/1     Running   0          3m21s
 ```
 
-### Migrate the local cluster to the Fleet default cluster?
-
-For users who want to deploy to the local cluster as well, they may move the cluster from `fleet-local` to `fleet-default` in the Rancher UI as follows:
-
-- To get to Fleet in Rancher, click ☰ > Continuous Delivery.
-- Under the **Clusters** menu, select the **local** cluster by checking the box to the left.
-- Select **Assign to** from the tabs above the cluster.
-- Select **`fleet-default`** from the **Assign Cluster To** dropdown.
-
-**Result**: The cluster will be migrated to `fleet-default`.
-
 ### Enable debug logging for `fleet-controller` and `fleet-agent`?
 
 Available in Rancher v2.6.3 (Fleet v0.3.8), the ability to enable debug logging has been added.
 
-- Go to the **Dashboard**, then click on the **local cluster** in the left navigation menu 
-- Select **Apps & Marketplace**, then **Installed Apps** from the dropdown 
+- Go to the **Dashboard**, then click on the **local cluster** in the left navigation menu
+- Select **Apps & Marketplace**, then **Installed Apps** from the dropdown
 - From there, you will upgrade the Fleet chart with the value `debug=true`. You can also set `debugLevel=5` if desired.
 
 ## **Additional Solutions for Other Fleet Issues**
@@ -233,7 +222,11 @@ You can force a redeployment of an agent for a given cluster by setting `redeplo
 kubectl patch clusters.fleet.cattle.io -n fleet-local local --type=json -p '[{"op": "add", "path": "/spec/redeployAgentGeneration", "value": -1}]'
 ```
 
-
 ### Nested GitRepo CRs
 
 Managing Fleet within Fleet (nested `GitRepo` usage) is not currently supported. We will update the documentation if support becomes available.
+
+### Migrate the local cluster to the Fleet default cluster workspace?
+
+Users can create new workspaces and move clusters across workspaces.
+It's currently not possible to move the local cluster from `fleet-local` to another workspace.


### PR DESCRIPTION
Cluster migration is more difficult


Refers to https://github.com/rancher/fleet/issues/1489