### PR TITLE
Update bundle-diffs.md for broken URL

### DIFF
--- a/docs/bundle-diffs.md
+++ b/docs/bundle-diffs.md
@@ -20,7 +20,9 @@ With the patch, users can instruct fleet to ignore object modifications.
 
 ## Simple Example
 
-https://github.com/rancher/fleet-examples/tree/master/bundle-diffs
+In this simple example, we create a Service and ConfigMap that we apply a bundle diff onto.
+
+https://github.com/rancher/fleet-test-data/tree/master/bundle-diffs
 
 
 ## Gatekeeper Example


### PR DESCRIPTION
This change fixes a URL that now 404s after repo structure changes. This fixes the 404 caused by https://github.com/rancher/fleet-examples/pull/39