### PR TITLE
Fix case mistake in helmRepoURLRegex property

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -104,7 +104,7 @@ Just like with SSH, reference the secret in your GitRepo resource via `clientSec
 :::warning
 The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
 Make sure you don't leak credentials by mixing public and private repositories. Use [different helm credentials for each path](#use-different-helm-credentials-for-each-path),
-or split them into different gitrepos, or use `helmRepoUrlRegex` to limit the scope of credentials to certain servers.
+or split them into different gitrepos, or use `helmRepoURLRegex` to limit the scope of credentials to certain servers.
 :::
 
 For a private Helm repo, users can reference a secret with the following keys:

--- a/docs/ref-gitrepo.md
+++ b/docs/ref-gitrepo.md
@@ -53,7 +53,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
   # Credentials will always be used if it is empty or not provided
   #
-  # helmRepoUrlRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts.rancher.io/*
   #
   # To add additional ca-bundle for self-signed certs, caBundle can be
   # filled with base64 encoded pem data. For example:

--- a/versioned_docs/version-0.6/gitrepo-add.md
+++ b/versioned_docs/version-0.6/gitrepo-add.md
@@ -151,7 +151,7 @@ Just like with SSH, reference the secret in your GitRepo resource via `clientSec
 :::warning
 The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
 Make sure you don't leak credentials by mixing public and private repositories. Split them into different gitrepos, or use
-`helmRepoUrlRegex` to limit the scope of credentials to certain servers.
+`helmRepoURLRegex` to limit the scope of credentials to certain servers.
 :::
 
 For a private Helm repo, users can reference a secret with the following keys:

--- a/versioned_docs/version-0.6/ref-gitrepo.md
+++ b/versioned_docs/version-0.6/ref-gitrepo.md
@@ -53,7 +53,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression. 
   # Credentials will always be used if it is empty or not provided
   # 
-  # helmRepoUrlRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts.rancher.io/*
   #
   # To add additional ca-bundle for self-signed certs, caBundle can be
   # filled with base64 encoded pem data. For example:

--- a/versioned_docs/version-0.7/gitrepo-add.md
+++ b/versioned_docs/version-0.7/gitrepo-add.md
@@ -105,7 +105,7 @@ Just like with SSH, reference the secret in your GitRepo resource via `clientSec
 :::warning
 The credentials will be used unconditionally for all Helm repositories referenced by the gitrepo resource.
 Make sure you don't leak credentials by mixing public and private repositories. Use [different helm credentials for each path](#use-different-helm-credentials-for-each-path),
-or split them into different gitrepos, or use `helmRepoUrlRegex` to limit the scope of credentials to certain servers.
+or split them into different gitrepos, or use `helmRepoURLRegex` to limit the scope of credentials to certain servers.
 :::
 
 For a private Helm repo, users can reference a secret with the following keys:

--- a/versioned_docs/version-0.7/ref-gitrepo.md
+++ b/versioned_docs/version-0.7/ref-gitrepo.md
@@ -53,7 +53,7 @@ spec:
   # Helm credentials from helmSecretName will be used if the helm repository url matches this regular expression.
   # Credentials will always be used if it is empty or not provided
   #
-  # helmRepoUrlRegex: https://charts.rancher.io/*
+  # helmRepoURLRegex: https://charts.rancher.io/*
   #
   # To add additional ca-bundle for self-signed certs, caBundle can be
   # filled with base64 encoded pem data. For example:


### PR DESCRIPTION
This field is spelled `helmRepoURLRegex` in the custom resource definition.