### PR TITLE
remove future features from docs

### DIFF
--- a/versioned_docs/version-0.7/ref-fleet-yaml.md
+++ b/versioned_docs/version-0.7/ref-fleet-yaml.md
@@ -182,8 +182,6 @@ targetCustomizations:
       region: us-east
   # A specific clusterGroup by name that will be selected
   clusterGroup: group1
-  # Resources will not be deployed in the matched clusters if doNotDeploy is true.
-  doNotDeploy: false
 
 # dependsOn allows you to configure dependencies to other bundles. The current bundle
 # will only be deployed, after all dependencies are deployed and in a Ready state.
@@ -204,10 +202,4 @@ ignore:
   # In this example a condition will be ignored if it contains {"type": "Active", "status", "False"}
   - type: Active
     status: "False"
-
-# Override targets defined in the GitRepo. The Bundle will not have any targets from the GitRepo if overrideTargets is provided.
-overrideTargets:
-  - clusterSelector:
-      matchLabels:
-        env: dev
 ```


### PR DESCRIPTION
several features of 0.8 are present in the 0.7 docs. These features do not work in 0.7 so they should not be in the docs.