### PR TITLE
Add workflow to automate docusaurus version update

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,42 @@
+---
+name: "Updatecli"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 * * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      #   cache: yarn
+      
+      #  https://github.com/actions/setup-node/issues/490
+      - name: Repair NPM  # Update to latest npm and yarn
+        run: "npm install -g npm yarn"
+
+      - name: Install Dependencies
+        run: "yarn install --frozen-lockfile"
+
+      - name: Install Updatecli Binary
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli in enforce mode
+        run: "updatecli apply --config ./updatecli/updatecli.d"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/updatecli.d/docusaurus.yaml
+++ b/updatecli/updatecli.d/docusaurus.yaml
@@ -1,0 +1,87 @@
+name: Bump Fleet version in documentaton
+
+actions:
+  default:
+    title: 'Bump Fleet version in documentation to {{ source "version" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      labels:
+        - chore
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: fleet-bot
+      email: bot@rancher.io
+      owner: rancher
+      repository: fleet-docs
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      branch: main
+
+sources:
+  version:
+    name: Get latest Fleet version
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: fleet
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+        # We want to ignore pre-release version
+        # According the library documentation used by updatecli
+        # https://github.com/Masterminds/semver#working-with-prerelease-versions
+        # the following rule, should do the trick
+        pattern: ">0.1"
+    transformers:
+        - trimprefix: v
+        - findsubmatch:
+            # Remove once if we decide to only keep major and minor version such as 0.7
+            pattern: '^(\d*).(\d*)'
+            # pattern: '^(\d*).(\d*).(\d*)'
+            captureindex: 0
+        # Uncomment if we decide to only version based on minor version
+        # so we could have 0.7.x
+        #- addSuffix: ".x"
+
+targets:
+  # Required yarn to be installed
+  docusaurus:
+    kind: shell
+    name: "Set latest docusaurus version"
+    scmid: default
+    disablesourceinput: true
+    spec:
+      # epinio source value is automatically added to the command as a parameter
+      environments:
+        - name: PATH
+      # The following script is designed to be working on Linux environment
+      command: |+
+        #!/bin/sh
+        # Testing that we can run yarn command from the GitHub Runner
+        yarn --help > /dev/null
+        VERSION='{{ source "version"}}'
+        if [ -z "$VERSION" ]
+        then
+          echo "Empty version provided"
+        fi
+        if [ ! -d "versioned_docs/version-$VERSION" ]
+        then
+          # DRY_RUN is the environment variable used by Updatecli
+          # to know if Updatecli is execute in DRY_RUN mode or APPLY mode
+          if test "$DRY_RUN" == "true"
+          then
+            echo "**DRY_RUN** new version $VERSION will be created"
+          exit 0
+          fi
+          # Install dependencies to tmp directory
+          yarn install --frozen-lockfile
+          yarn run docusaurus docs:version "$VERSION"
+        fi
+


### PR DESCRIPTION
This pullrequest add an updatecli manifest to run the command  `yarn run docusaurus docs:version "$VERSION"` if a new version of type Major.Minor is available

I reused the same Updatecli manifest than the one on the Epinio project which generated PR such as https://github.com/epinio/docs/pull/245

I tested the manifest locally but I can't see how it behaves on this GitHub Action.
