### PR TITLE
Document bundle size issue with target-customised chart version

### DIFF
--- a/docs/gitrepo-targets.md
+++ b/docs/gitrepo-targets.md
@@ -170,6 +170,13 @@ Fleet will deploy the Helm chart with your customized `values.yaml` to the diffe
 * [Helm.ValuesFrom](/ref-crds#helmoptions)
 * [Helm.Values](/ref-crds#helmoptions)
 * [Helm.Version](/ref-crds#helmoptions)
+:::warning important information
+Overriding the version of a Helm chart via target customizations will lead to bundles containing _all_ versions, ie the
+default one and the custom one(s), of the chart, to accommodate all clusters. This in turn means that Fleet will deploy larger bundles.
+
+As Fleet stores bundles via etcd, this may cause issues on some clusters where resultant bundle sizes may exceed etcd's
+configured maximum blob size. See [this issue](https://github.com/rancher/fleet/issues/1650) for more details.
+:::
 * [Helm.WaitForJobs](/ref-crds#helmoptions)
 * [Kustomize.Dir](/ref-crds#kustomizeoptions)
 * [YAML.Overlays](/ref-crds#yamloptions)

--- a/docs/gitrepo-targets.md
+++ b/docs/gitrepo-targets.md
@@ -170,13 +170,16 @@ Fleet will deploy the Helm chart with your customized `values.yaml` to the diffe
 * [Helm.ValuesFrom](/ref-crds#helmoptions)
 * [Helm.Values](/ref-crds#helmoptions)
 * [Helm.Version](/ref-crds#helmoptions)
-:::warning important information
-Overriding the version of a Helm chart via target customizations will lead to bundles containing _all_ versions, ie the
-default one and the custom one(s), of the chart, to accommodate all clusters. This in turn means that Fleet will deploy larger bundles.
 
-As Fleet stores bundles via etcd, this may cause issues on some clusters where resultant bundle sizes may exceed etcd's
-configured maximum blob size. See [this issue](https://github.com/rancher/fleet/issues/1650) for more details.
-:::
+  :::warning important information
+  Overriding the version of a Helm chart via target customizations will lead to bundles containing _all_ versions, ie the
+  default one and the custom one(s), of the chart, to accommodate all clusters. This in turn means that Fleet will
+  deploy larger bundles.
+
+  As Fleet stores bundles via etcd, this may cause issues on some clusters where resultant bundle sizes may exceed
+  etcd's configured maximum blob size. See [this issue](https://github.com/rancher/fleet/issues/1650) for more details.
+  :::
+
 * [Helm.WaitForJobs](/ref-crds#helmoptions)
 * [Kustomize.Dir](/ref-crds#kustomizeoptions)
 * [YAML.Overlays](/ref-crds#yamloptions)

--- a/versioned_docs/version-0.6/gitrepo-targets.md
+++ b/versioned_docs/version-0.6/gitrepo-targets.md
@@ -136,6 +136,14 @@ Fleet will deploy the Helm chart with your customized `values.yaml` to the diffe
 
 >**Note:** Configuration management is not limited to deployments but can be expanded to general configuration management. Fleet is able to apply configuration management through customization among any set of clusters automatically.
 
+:::warning important information
+Overriding the version of a Helm chart via target customizations will lead to bundles containing _all_ versions, ie the
+default one and the custom one(s), of the chart, to accommodate all clusters. This in turn means that Fleet will deploy larger bundles.
+
+As Fleet stores bundles via etcd, this may cause issues on some clusters where resultant bundle sizes may exceed etcd's
+configured maximum blob size. See [this issue](https://github.com/rancher/fleet/issues/1650) for more details.
+:::
+
 ## Additional Examples
 
 Examples using raw Kubernetes YAML, Helm charts, Kustomize, and combinations

--- a/versioned_docs/version-0.7/gitrepo-targets.md
+++ b/versioned_docs/version-0.7/gitrepo-targets.md
@@ -161,6 +161,13 @@ Fleet will deploy the Helm chart with your customized `values.yaml` to the diffe
 * [Helm.ValuesFrom](/ref-crds#helmoptions)
 * [Helm.Values](/ref-crds#helmoptions)
 * [Helm.Version](/ref-crds#helmoptions)
+:::warning important information
+Overriding the version of a Helm chart via target customizations will lead to bundles containing _all_ versions, ie the
+default one and the custom one(s), of the chart, to accommodate all clusters. This in turn means that Fleet will deploy larger bundles.
+
+As Fleet stores bundles via etcd, this may cause issues on some clusters where resultant bundle sizes may exceed etcd's
+configured maximum blob size. See [this issue](https://github.com/rancher/fleet/issues/1650) for more details.
+:::
 * [Helm.WaitForJobs](/ref-crds#helmoptions)
 * [Kustomize.Dir](/ref-crds#kustomizeoptions)
 * [YAML.Overlays](/ref-crds#yamloptions)

--- a/versioned_docs/version-0.7/gitrepo-targets.md
+++ b/versioned_docs/version-0.7/gitrepo-targets.md
@@ -161,13 +161,16 @@ Fleet will deploy the Helm chart with your customized `values.yaml` to the diffe
 * [Helm.ValuesFrom](/ref-crds#helmoptions)
 * [Helm.Values](/ref-crds#helmoptions)
 * [Helm.Version](/ref-crds#helmoptions)
-:::warning important information
-Overriding the version of a Helm chart via target customizations will lead to bundles containing _all_ versions, ie the
-default one and the custom one(s), of the chart, to accommodate all clusters. This in turn means that Fleet will deploy larger bundles.
 
-As Fleet stores bundles via etcd, this may cause issues on some clusters where resultant bundle sizes may exceed etcd's
-configured maximum blob size. See [this issue](https://github.com/rancher/fleet/issues/1650) for more details.
-:::
+  :::warning important information
+  Overriding the version of a Helm chart via target customizations will lead to bundles containing _all_ versions, ie the
+  default one and the custom one(s), of the chart, to accommodate all clusters. This in turn means that Fleet will
+  deploy larger bundles.
+
+  As Fleet stores bundles via etcd, this may cause issues on some clusters where resultant bundle sizes may exceed
+  etcd's configured maximum blob size. See [this issue](https://github.com/rancher/fleet/issues/1650) for more details.
+  :::
+
 * [Helm.WaitForJobs](/ref-crds#helmoptions)
 * [Kustomize.Dir](/ref-crds#kustomizeoptions)
 * [YAML.Overlays](/ref-crds#yamloptions)


### PR DESCRIPTION
Refers to [fleet#1650](https://github.com/rancher/fleet/issues/1650).

This adds a warning for Fleet versions from 0.6 onwards about bundle sizes which may exceed etcd's maximum blob size for bundles containing multiple versions of a chart as a result of target customisations.

Fleet versions prior to 0.6 did not properly support multiple chart versions per bundle, hence that warning is not relevant for them.