### PR TITLE
Bump Node version to 20.x in GitHub Action workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Docusaurus
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: yarn
       - name: Build website
         run: |

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
       #   cache: yarn
       
       #  https://github.com/actions/setup-node/issues/490


### PR DESCRIPTION
Node 16 is out of maintainance now