### PR TITLE
GitRepo Resource Creation Documentation Clarification

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -76,7 +76,7 @@ stringData:
 
 :::warning
 
-If you don't add it any server's public key will be trusted and added. (`ssh -o stricthostkeychecking=accept-new` will be used)
+If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o stricthostkeychecking=accept-new` will be used)
 
 :::
 

--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -52,6 +52,14 @@ The key has to be in PEM format.
 
 :::
 
+### Known hosts
+
+:::warning
+
+If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o stricthostkeychecking=accept-new` will be used)
+
+:::
+
 Fleet supports putting `known_hosts` into ssh secret. Here is an example of how to add it:
 
 Fetch the public key hash(take github as an example)
@@ -73,12 +81,6 @@ stringData:
   known_hosts: |-
     |1|YJr1VZoi6dM0oE+zkM0do3Z04TQ=|7MclCn1fLROZG+BgR4m1r8TLwWc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 ```
-
-:::warning
-
-If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o stricthostkeychecking=accept-new` will be used)
-
-:::
 
 :::info
 


### PR DESCRIPTION
# Issue

While reading the GitRepo documentation at https://fleet.rancher.io/gitrepo-add I found myself confused by some ambiguity in the documentation. I've fixed two issues that I found to be rather important.

# Corrections

1. Alter the language used in the warning regarding known hosts.

The purpose of this change is to bring clarity to what the writer's intent was when using the word "it" to specifically mean a public key. As well I've added a comma to help split the sentence grammatically. Each change independently I found to not be a full solution, but combined make readability a lot easier.

2. Add a header format to the known hosts section and move the warning

I felt that the known hosts section was not immediately recognizable as its own specific section/in addition to, so making it a tertiary header helps a lot visually.

The warning that explains public keys will be automatically trusted should be near the top, as that is information you need prior to making a decision on whether or not you want to add public keys to the secret ahead of time. It is a fundamental concern to the content, so in my mind it should be pushed to the top.

Thank you team!