### PR TITLE
Updates fleet repository links after moving to main

### DIFF
--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -6,9 +6,9 @@ A reference list of, mostly internal, configuration options.
 
 The Helm charts accept, at least, the options as shown with their default in `values.yaml`:
 
-* https://github.com/rancher/fleet/blob/master/charts/fleet/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-crds/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-agent/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-crds/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-agent/values.yaml
 
 ## Environment Variables
 
@@ -16,13 +16,13 @@ The controllers can be started with these environment variables:
 
 * `CATTLE_DEV_MODE` - used to debug wrangler, not usable
 * `FLEET_CLUSTER_ENQUEUE_DELAY` - tune how often non-ready clusters are checked
-* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/master/docs/performance.md)
+* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/main/docs/performance.md)
 
 ## Configuration
 
 In cluster configuration for the agent and fleet manager. Changing these can lead to full re-deployments.
 
-The config [struct](https://github.com/rancher/fleet/blob/master/pkg/config/config.go#L40-L52) is used in both config maps:
+The config [struct](https://github.com/rancher/fleet/blob/main/pkg/config/config.go#L40-L52) is used in both config maps:
 
 * cattle-fleet-system/fleet-agent
 * cattle-fleet-system/fleet-controller

--- a/versioned_docs/version-0.6/ref-configuration.md
+++ b/versioned_docs/version-0.6/ref-configuration.md
@@ -6,9 +6,9 @@ A reference list of, mostly internal, configuration options.
 
 The Helm charts accept, at least, the options as shown with their default in `values.yaml`:
 
-* https://github.com/rancher/fleet/blob/master/charts/fleet/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-crds/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-agent/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-crds/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-agent/values.yaml
 
 ## Environment Variables
 
@@ -16,13 +16,13 @@ The controllers can be started with these environment variables:
 
 * `CATTLE_DEV_MODE` - used to debug wrangler, not usable
 * `FLEET_CLUSTER_ENQUEUE_DELAY` - tune how often non-ready clusters are checked
-* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/master/docs/performance.md)
+* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/main/docs/performance.md)
 
 ## Configuration
 
 In cluster configuration for the agent and fleet manager. Changing these can lead to full re-deployments.
 
-The config [struct](https://github.com/rancher/fleet/blob/master/pkg/config/config.go#L40-L52) is used in both config maps:
+The config [struct](https://github.com/rancher/fleet/blob/main/pkg/config/config.go#L40-L52) is used in both config maps:
 
 * cattle-fleet-system/fleet-agent 
 * cattle-fleet-system/fleet-controller 

--- a/versioned_docs/version-0.6/ref-fleet-yaml.md
+++ b/versioned_docs/version-0.6/ref-fleet-yaml.md
@@ -4,7 +4,7 @@ The `fleet.yaml` file adds options to a bundle. Any directory with a `fleet.yaml
 
 For more information on how to use the `fleet.yaml` to customize bundles see [Git Repository Contents](./gitrepo-content.md).
 
-The content of the fleet.yaml corresponds to https://github.com/rancher/fleet/blob/master/pkg/bundlereader/read.go#L129-L135, which contains the [BundleSpec](./ref-crds#bundlespec).
+The content of the fleet.yaml corresponds to https://github.com/rancher/fleet/blob/main/pkg/bundlereader/read.go#L129-L135, which contains the [BundleSpec](./ref-crds#bundlespec).
 
 ### Reference
 

--- a/versioned_docs/version-0.7/ref-configuration.md
+++ b/versioned_docs/version-0.7/ref-configuration.md
@@ -6,9 +6,9 @@ A reference list of, mostly internal, configuration options.
 
 The Helm charts accept, at least, the options as shown with their default in `values.yaml`:
 
-* https://github.com/rancher/fleet/blob/master/charts/fleet/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-crds/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-agent/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-crds/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-agent/values.yaml
 
 ## Environment Variables
 
@@ -16,13 +16,13 @@ The controllers can be started with these environment variables:
 
 * `CATTLE_DEV_MODE` - used to debug wrangler, not usable
 * `FLEET_CLUSTER_ENQUEUE_DELAY` - tune how often non-ready clusters are checked
-* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/master/docs/performance.md)
+* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/main/docs/performance.md)
 
 ## Configuration
 
 In cluster configuration for the agent and fleet manager. Changing these can lead to full re-deployments.
 
-The config [struct](https://github.com/rancher/fleet/blob/master/pkg/config/config.go#L40-L52) is used in both config maps:
+The config [struct](https://github.com/rancher/fleet/blob/main/pkg/config/config.go#L40-L52) is used in both config maps:
 
 * cattle-fleet-system/fleet-agent
 * cattle-fleet-system/fleet-controller

--- a/versioned_docs/version-0.8/ref-configuration.md
+++ b/versioned_docs/version-0.8/ref-configuration.md
@@ -6,9 +6,9 @@ A reference list of, mostly internal, configuration options.
 
 The Helm charts accept, at least, the options as shown with their default in `values.yaml`:
 
-* https://github.com/rancher/fleet/blob/master/charts/fleet/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-crds/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-agent/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-crds/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-agent/values.yaml
 
 ## Environment Variables
 
@@ -16,13 +16,13 @@ The controllers can be started with these environment variables:
 
 * `CATTLE_DEV_MODE` - used to debug wrangler, not usable
 * `FLEET_CLUSTER_ENQUEUE_DELAY` - tune how often non-ready clusters are checked
-* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/master/docs/performance.md)
+* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/main/docs/performance.md)
 
 ## Configuration
 
 In cluster configuration for the agent and fleet manager. Changing these can lead to full re-deployments.
 
-The config [struct](https://github.com/rancher/fleet/blob/master/pkg/config/config.go#L40-L52) is used in both config maps:
+The config [struct](https://github.com/rancher/fleet/blob/main/pkg/config/config.go#L40-L52) is used in both config maps:
 
 * cattle-fleet-system/fleet-agent
 * cattle-fleet-system/fleet-controller

--- a/versioned_docs/version-0.9/ref-configuration.md
+++ b/versioned_docs/version-0.9/ref-configuration.md
@@ -6,9 +6,9 @@ A reference list of, mostly internal, configuration options.
 
 The Helm charts accept, at least, the options as shown with their default in `values.yaml`:
 
-* https://github.com/rancher/fleet/blob/master/charts/fleet/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-crds/values.yaml
-* https://github.com/rancher/fleet/blob/master/charts/fleet-agent/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-crds/values.yaml
+* https://github.com/rancher/fleet/blob/main/charts/fleet-agent/values.yaml
 
 ## Environment Variables
 
@@ -16,13 +16,13 @@ The controllers can be started with these environment variables:
 
 * `CATTLE_DEV_MODE` - used to debug wrangler, not usable
 * `FLEET_CLUSTER_ENQUEUE_DELAY` - tune how often non-ready clusters are checked
-* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/master/docs/performance.md)
+* `FLEET_CPU_PPROF_PERIOD` - used to turn on [performance profiling](https://github.com/rancher/fleet/blob/main/docs/performance.md)
 
 ## Configuration
 
 In cluster configuration for the agent and fleet manager. Changing these can lead to full re-deployments.
 
-The config [struct](https://github.com/rancher/fleet/blob/master/pkg/config/config.go#L40-L52) is used in both config maps:
+The config [struct](https://github.com/rancher/fleet/blob/main/pkg/config/config.go#L40-L52) is used in both config maps:
 
 * cattle-fleet-system/fleet-agent
 * cattle-fleet-system/fleet-controller


### PR DESCRIPTION
This PR should be merged after https://github.com/rancher/fleet/pull/2240

It replaces all `fleet` repo references from `master` to `main`

Refers to: https://github.com/rancher/fleet/issues/2234