### PR TITLE
Add sections to fleet yaml reference for helm options

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -82,12 +82,6 @@ stringData:
     |1|YJr1VZoi6dM0oE+zkM0do3Z04TQ=|7MclCn1fLROZG+BgR4m1r8TLwWc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 ```
 
-:::info
-
-If you are using openssh format for the private key and you are creating it in the UI, make sure a carriage return is appended in the end of the private key.
-
-:::
-
 ### Using HTTP Auth
 
 Create a secret containing username and password. You can replace the password with a personal access token if necessary. Also see [HTTP secrets in Github](./troubleshooting#http-secrets-in-github).

--- a/docs/ref-fleet-yaml.md
+++ b/docs/ref-fleet-yaml.md
@@ -211,8 +211,8 @@ targetCustomizations:
   # Resources will not be deployed in the matched clusters if doNotDeploy is true.
   doNotDeploy: false
   # Drift correction removes any external change made to resources managed by Fleet. It performs a helm rollback, which uses
-  # a three-way merge strategy by default. 
-  # It will try to update all resources by doing a PUT request if force is enabled. Three-way strategic merge might fail when updating 
+  # a three-way merge strategy by default.
+  # It will try to update all resources by doing a PUT request if force is enabled. Three-way strategic merge might fail when updating
   # an item inside of an array as it will try to add a new item instead of replacing the existing one. This can be fixed by using force.
   # Keep in mind that resources might be recreated if force is enabled.
   # Failed rollback will be removed from the helm history unless keepFailHistory is set to true.
@@ -250,3 +250,43 @@ overrideTargets:
         env: dev
 
 ```
+
+### Helm Options
+
+#### How fleet-agent deploys the bundle
+
+These options also apply to kustomize- and manifest-style bundles.
+They control how the fleet-agent deploys the bundle. All bundles are converted into Helm charts and deployed with the Helm SDK.
+These options are often similar to the Helm CLI options for install and update.
+
+* releaseName
+* takeOwnership
+* force
+* atomic
+* disablePreProcess
+* disableDNS
+* skipSchemaValidation
+* waitForJobs
+
+#### Helm Chart Download Options
+
+These options are for Helm style bundles, they specify how to download the chart.
+
+* chart
+* repo
+* version
+
+The reference to the chart can be either:
+* a local path in the cloned Git repository, specified by `chart`.
+* a go-getter URL, specified by `chart`. This can be used to download a tarball
+  of the chart. go-getter also allows to download a chart from a Git repo.
+* a Helm repository, specified by `repo` and optionally `version`.
+* a OCI Helm repository, specified by `repo` and optionally `version`.
+
+#### Helm Chart Value Options
+
+Options for the downloaded Helm chart.
+
+* values
+* valuesFiles
+* valueFrom

--- a/docs/ref-fleet-yaml.md
+++ b/docs/ref-fleet-yaml.md
@@ -270,7 +270,7 @@ These options are often similar to the Helm CLI options for install and update.
 
 #### Helm Chart Download Options
 
-These options are for Helm style bundles, they specify how to download the chart.
+These options are for Helm-style bundles, they specify how to download the chart.
 
 * chart
 * repo
@@ -278,10 +278,10 @@ These options are for Helm style bundles, they specify how to download the chart
 
 The reference to the chart can be either:
 * a local path in the cloned Git repository, specified by `chart`.
-* a go-getter URL, specified by `chart`. This can be used to download a tarball
+* a [go-getter URL](https://github.com/hashicorp/go-getter?tab=readme-ov-file#url-format), specified by `chart`. This can be used to download a tarball
   of the chart. go-getter also allows to download a chart from a Git repo.
 * a Helm repository, specified by `repo` and optionally `version`.
-* a OCI Helm repository, specified by `repo` and optionally `version`.
+* an OCI Helm repository, specified by `repo` and optionally `version`.
 
 #### Helm Chart Value Options
 


### PR DESCRIPTION
refers to https://github.com/rancher/fleet/issues/1606

The existing inline documentation is getting too long and hard to read. This adds information on the different types of downloaders.