### PR TITLE
Add docs for static sharding

### DIFF
--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -38,6 +38,11 @@ Labels used by fleet:
 * `fleet.cattle.io/bundle-name` - used on BundleDeployment to reference the Bundle resource
 * `fleet.cattle.io/managed=true` - cluster namespaces with this label will be cleaned up. Other resources will be cleaned up if it is in a label. Used in Rancher to identify fleet namespaces.
 * `fleet.cattle.io/bootstrap-token` - unused
+* `fleet.cattle.io/shard=<shard-id>` - Shard ID assigned by Fleet to resources, inherited from a `GitRepo`, which
+  determines which Fleet controller deployment will reconcile them.
+    * If this label is not provided or has an empty value, then the unsharded Fleet controller will process the resource.
+    * If this label has a value which does not match any shard ID for which a Fleet controller is deployed, then the
+      resource will not be processed.
 
 
 ## Annotations


### PR DESCRIPTION
This commit documents static sharding support in terms of installation and use.

Refers to [fleet#1740](https://github.com/rancher/fleet/issues/1740).