### PR TITLE
Remove CLI args, which are non-functional

### DIFF
--- a/docs/cli/fleet-agent/fleet-agent_clusterstatus.md
+++ b/docs/cli/fleet-agent/fleet-agent_clusterstatus.md
@@ -21,13 +21,7 @@ fleet-agent clusterstatus [flags]
       --namespace string          system namespace is the namespace, the agent runs in, e.g. cattle-fleet-system
 ```
 
-### Options inherited from parent commands
-
-```
-      --agent-scope string   An identifier used to scope the agent bundleID names, typically the same as namespace
-```
-
 ### SEE ALSO
 
-* [fleet-agent](./fleet-agent)	 - 
+* [fleet-agent](./fleet-agent)	 -
 

--- a/docs/cli/fleet-agent/fleet-agent_register.md
+++ b/docs/cli/fleet-agent/fleet-agent_register.md
@@ -20,13 +20,7 @@ fleet-agent register [flags]
       --namespace string    system namespace is the namespace, the agent runs in, e.g. cattle-fleet-system
 ```
 
-### Options inherited from parent commands
-
-```
-      --agent-scope string   An identifier used to scope the agent bundleID names, typically the same as namespace
-```
-
 ### SEE ALSO
 
-* [fleet-agent](./fleet-agent)	 - 
+* [fleet-agent](./fleet-agent)	 -
 

--- a/docs/cli/fleet-controller/fleet-manager_agentmanagement.md
+++ b/docs/cli/fleet-controller/fleet-manager_agentmanagement.md
@@ -24,12 +24,9 @@ fleet-manager agentmanagement [flags]
 ```
       --debug             Turn on debug logging
       --debug-level int   If debugging is enabled, set klog -v=X
-      --disable-gitops    disable gitops components
-      --disable-metrics   disable metrics
-      --shard-id string   only manage resources labeled with a specific shard ID
 ```
 
 ### SEE ALSO
 
-* [fleet-manager](./fleet-manager)	 - 
+* [fleet-manager](./fleet-manager)	 -
 

--- a/docs/cli/fleet-controller/fleet-manager_cleanup.md
+++ b/docs/cli/fleet-controller/fleet-manager_cleanup.md
@@ -23,12 +23,9 @@ fleet-manager cleanup [flags]
 ```
       --debug             Turn on debug logging
       --debug-level int   If debugging is enabled, set klog -v=X
-      --disable-gitops    disable gitops components
-      --disable-metrics   disable metrics
-      --shard-id string   only manage resources labeled with a specific shard ID
 ```
 
 ### SEE ALSO
 
-* [fleet-manager](./fleet-manager)	 - 
+* [fleet-manager](./fleet-manager)	 -
 


### PR DESCRIPTION
We should clean up flags in the future. The default root commands set their flags as global.