### PR TITLE
fix: add generic changelog for next release

### DIFF
--- a/docs/changelogs/changelogs/next.md
+++ b/docs/changelogs/changelogs/next.md
@@ -1,0 +1,5 @@
+---
+title: "Next 🚧"
+---
+
+We are still working on the next release.

--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -1,0 +1,5 @@
+---
+title: "Next 🚧"
+---
+
+We are still working on the next release.


### PR DESCRIPTION
Because of this setting https://github.com/rancher/fleet-docs/blob/cf094e78a26d61c1eab5737aa35e60338006a59d/sidebars.js#L84 

The website doesn't build if the changelog directory is empty