### PR TITLE
deps(updatecli): Bump docusaurus/releasepost policy

### DIFF
--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -12,7 +12,7 @@ policies:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/fleet.yaml
   - name: Handle releasepost
-    policy: ghcr.io/olblak/rancherlabs-policies/docusaurus/releasepost:0.3.0@sha256:82b4302cdf62d29b3c819c15a4d08d7f6625f175b9fd32129a231a21861f3cf1
+    policy: ghcr.io/olblak/rancherlabs-policies/docusaurus/releasepost:0.4.0
     values:
       - updatecli/values.d/scm.yaml
       - updatecli/values.d/fleet.yaml


### PR DESCRIPTION
Bump to a new docusaurus/releasepost policy that will correctly set links and remove obsolete changelog files
cfr [updatecli/releasepost](https://github.com/updatecli/releasepost/releases/tag/v0.5.0)