### PR TITLE
Fix `fleet apply` command description

### DIFF
--- a/docs/cli/fleet-cli/fleet.md
+++ b/docs/cli/fleet-cli/fleet.md
@@ -18,7 +18,7 @@ fleet [flags]
 
 ### SEE ALSO
 
-* [fleet apply](./fleet_apply)	 - Render a bundle into a Kubernetes resource and apply it in the Fleet Manager
+* [fleet apply](./fleet_apply)	 - Create bundles from directories, and output them or apply them on a cluster
 * [fleet cleanup](./fleet_cleanup)	 - Clean up outdated cluster registrations
 * [fleet deploy](./fleet_deploy)	 - Deploy a bundledeployment/content resource to a cluster, by creating a Helm release. This will not deploy the bundledeployment/content resources directly to the cluster.
 * [fleet gitcloner](./fleet_gitcloner)	 - Clones a git repository

--- a/docs/cli/fleet-cli/fleet_apply.md
+++ b/docs/cli/fleet-cli/fleet_apply.md
@@ -4,7 +4,7 @@ sidebar_label: "fleet apply"
 ---
 ## fleet apply
 
-Render a bundle into a Kubernetes resource and apply it in the Fleet Manager
+Create bundles from directories, and output them or apply them on a cluster
 
 ```
 fleet apply [flags] BUNDLE_NAME PATH...


### PR DESCRIPTION
That command does not render bundles into Kubernetes resources, but rather creates bundles from directories, which can be either output or applied on a cluster.

Originates in [fleet#2467](https://github.com/rancher/fleet/pull/2467).