### PR TITLE
Fix broken link in Quick Start page

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,4 +84,4 @@ NAME       READY   UP-TO-DATE   AVAILABLE   AGE
 frontend   3/3     3            3           116m
 ```
 
-Enjoy and read the [docs](https://rancher.github.io/fleet).
+Enjoy and read the [docs](https://fleet.rancher.io/).


### PR DESCRIPTION
Fixing link to the fleet documentation in the Quick Start page, changing from https://rancher.github.io/fleet to https://fleet.rancher.io/