### PR TITLE
Elaborate on API_SERVER_URL in agent-initiated cluster reg

### DIFF
--- a/docs/cluster-registration.md
+++ b/docs/cluster-registration.md
@@ -77,7 +77,7 @@ API_SERVER_URL=https://<API_URL>:6443
 API_SERVER_CA_DATA=...
 ```
 
-`API_SERVER_URL` should be in format of `https://<API_URL>:6443` that can be referenced from `.kube/config` file. Do not use apiServerURL of `https://<FQDN>` from previously generated `values.yaml` file.
+If the API server is not listening on the https port (443), the `API_SERVER_URL` should include the port, e.g. `https://<API_URL>:6443`. The URL can be found in the `.kube/config` file.
 Value in `API_SERVER_CA_DATA` can be obtained from a `.kube/config` file with valid data to connect to the upstream cluster
 (under the `certificate-authority-data` key). Alternatively it can be obtained from within the upstream cluster itself,
 by looking up the default ServiceAccount secret name (typically prefixed with `default-token-`, in the default namespace),

--- a/docs/cluster-registration.md
+++ b/docs/cluster-registration.md
@@ -73,22 +73,16 @@ CLUSTER_LABELS="--set-string labels.example=true --set-string labels.env=dev"
 Third, set variables with the Fleet cluster's API Server URL and CA, for the downstream cluster to use for connecting.
 
 ```shell
-API_SERVER_URL=https://...
+API_SERVER_URL=https://<API_URL>:6443
 API_SERVER_CA_DATA=...
 ```
 
+`API_SERVER_URL` should be in format of `https://<API_URL>:6443` that can be referenced from `.kube/config` file. Do not use apiServerURL of `https://<FQDN>` from previously generated `values.yaml` file.
 Value in `API_SERVER_CA_DATA` can be obtained from a `.kube/config` file with valid data to connect to the upstream cluster
 (under the `certificate-authority-data` key). Alternatively it can be obtained from within the upstream cluster itself,
 by looking up the default ServiceAccount secret name (typically prefixed with `default-token-`, in the default namespace),
 under the `ca.crt` key.
 
-
-:::caution
-
-__Use proper namespace and release name__:
-For the agent chart the namespace must be `cattle-fleet-system` and the release name `fleet-agent`
-
-:::
 
 :::warning Kubectl Context
 
@@ -106,6 +100,14 @@ Add Fleet's Helm repo.
 <CodeBlock language="bash">
 {`helm repo add fleet https://rancher.github.io/fleet-helm-charts/`}
 </CodeBlock>
+
+:::caution
+
+__Use proper namespace and release name__:
+For the agent chart the namespace must be `cattle-fleet-system` and the release name `fleet-agent`
+
+:::
+
 
 Finally, install the agent using Helm.
 <Tabs>


### PR DESCRIPTION
I am a newbie in SUSE. I was playing with Fleet and hit this issue: https://github.com/rancher/fleet/issues/68

The doc doesn't indicate expected value for _API_SERVER_URL_ in helm install. There are 2 possible candidates for this value:
1. The URL in values.yaml, generated from the previous step (token generation)
_**apiServerURL**: https://[FQDN]_ such as _https://[rancher-ip].sslip.io_
2. _https://[kubeapi_url]:6443_

While following the steps, the users may take the 1st value, like I did. Developer clarified 2nd value should be used. Hence submitting this PR that specifies which value to be fed, and what not.

Also moved a caution for namespace to the right place, right before the helm install cmd, where this caution is required.

Thanks, Jiwon