### PR TITLE
Remove mentions to `--disable-gitops` in 0.10+

### DIFF
--- a/docs/cli/fleet-controller/fleetcontroller.md
+++ b/docs/cli/fleet-controller/fleetcontroller.md
@@ -15,7 +15,6 @@ fleetcontroller [flags]
 ```
       --debug                             Turn on debug logging
       --debug-level int                   If debugging is enabled, set klog -v=X
-      --disable-gitops                    disable gitops components
       --disable-metrics                   disable metrics
   -h, --help                              help for fleetcontroller
       --kubeconfig string                 Paths to a kubeconfig. Only required if out-of-cluster.

--- a/docs/cli/fleet-controller/fleetcontroller_gitjob.md
+++ b/docs/cli/fleet-controller/fleetcontroller_gitjob.md
@@ -28,7 +28,6 @@ fleetcontroller gitjob [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-gitops    disable gitops components
       --disable-metrics   disable metrics
       --shard-id string   only manage resources labeled with a specific shard ID
 ```

--- a/versioned_docs/version-0.10/cli/fleet-controller/fleetcontroller.md
+++ b/versioned_docs/version-0.10/cli/fleet-controller/fleetcontroller.md
@@ -15,7 +15,6 @@ fleetcontroller [flags]
 ```
       --debug                             Turn on debug logging
       --debug-level int                   If debugging is enabled, set klog -v=X
-      --disable-gitops                    disable gitops components
       --disable-metrics                   disable metrics
   -h, --help                              help for fleetcontroller
       --kubeconfig string                 Paths to a kubeconfig. Only required if out-of-cluster.

--- a/versioned_docs/version-0.10/cli/fleet-controller/fleetcontroller_gitjob.md
+++ b/versioned_docs/version-0.10/cli/fleet-controller/fleetcontroller_gitjob.md
@@ -27,7 +27,6 @@ fleetcontroller gitjob [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-gitops    disable gitops components
       --disable-metrics   disable metrics
       --shard-id string   only manage resources labeled with a specific shard ID
       --shard-node-selector string    node selector to apply to jobs based on the shard ID, if any


### PR DESCRIPTION
That flag no longer exists from Fleet 0.10 onwards.