### PR TITLE
Document node selectors for sharding

### DIFF
--- a/docs/cli/fleet-controller/fleetcontroller_gitjob.md
+++ b/docs/cli/fleet-controller/fleetcontroller_gitjob.md
@@ -22,6 +22,7 @@ fleetcontroller gitjob [flags]
       --listen string                 The port the webhook listens. (default ":8080")
       --metrics-bind-address string   The address the metric endpoint binds to. (default ":8081")
       --namespace string              namespace to watch (default "cattle-fleet-system")
+      --shard-node-selector string    node selector to apply to jobs based on the shard ID, if any
 ```
 
 ### Options inherited from parent commands

--- a/versioned_docs/version-0.10/cli/fleet-controller/fleetcontroller_gitjob.md
+++ b/versioned_docs/version-0.10/cli/fleet-controller/fleetcontroller_gitjob.md
@@ -30,6 +30,7 @@ fleetcontroller gitjob [flags]
       --disable-gitops    disable gitops components
       --disable-metrics   disable metrics
       --shard-id string   only manage resources labeled with a specific shard ID
+      --shard-node-selector string    node selector to apply to jobs based on the shard ID, if any
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
This updates sharding documentation to take node selectors, and the new sharding parameters syntax, into account.

Follow-up to https://github.com/rancher/fleet/pull/2505.
Refers to https://github.com/rancher/fleet/issues/2456.