### PR TITLE
fix: changed ociRegistry url field to actual reference field

### DIFF
--- a/docs/oci-storage.md
+++ b/docs/oci-storage.md
@@ -21,8 +21,8 @@ There are the fields involved:
 ```
 // when ociRegistry is defined Fleet will use oci registry as storage
 ociRegistry:
-    // url is the OCI registry url.
-    url: "docker.io/your-user-here"
+    // reference is the OCI registry url.
+    reference: "docker.io/your-user-here"
     // secret name where the credentials for the OCI registry are.
     // expects a generic secret with username and password keys set.
     authSecretName: oci-secret


### PR DESCRIPTION
This pull request aims to fix the wrong field for the ociRegistry struct.

In the code the field for the ociRegistry url is named reference.

Depending on the way you want to name this field you could also close this pull request and change the name in the code.