### PR TITLE
Update end-of-maintenance banners

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,7 +120,10 @@ module.exports = {
             current: {
               label: 'Next 🚧',
             },
-            '0.7': {
+            '0.10': {
+              banner: 'none',
+            },
+            '0.11': {
               banner: 'none',
             },
           },


### PR DESCRIPTION
Versions 0.10 and 0.11 are still maintained, whereas 0.7 is not.

Refers to https://github.com/rancher/fleet-docs/issues/213.