### PR TITLE
Add links to quick start page

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,4 +84,8 @@ NAME       READY   UP-TO-DATE   AVAILABLE   AGE
 frontend   3/3     3            3           116m
 ```
 
-Enjoy and read the [docs](https://fleet.rancher.io/).
+## Next steps
+
+Do you need to...
+* Monitor private git or Helm repositories? Check [this](./gitrepo-add.md).
+* Customise your deployments per target cluster? [This page](./gitrepo-targets.md) will help.


### PR DESCRIPTION
This may help newcomers to gradually find their way towards documentation covering more sophisticated use cases.

Refers to https://github.com/rancher/fleet/issues/2667.