### PR TITLE
Fix links on `fleet-agent` help page

### DIFF
--- a/docs/cli/fleet-agent/fleet-agent.md
+++ b/docs/cli/fleet-agent/fleet-agent.md
@@ -28,6 +28,6 @@ fleet-agent [flags]
 
 ### SEE ALSO
 
-* [fleet-agent clusterstatus](fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
-* [fleet-agent register](fleet-agent_register)	 - Register agent with an upstream cluster
+* [fleet-agent clusterstatus](fleet-agent/fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
+* [fleet-agent register](fleet-agent/fleet-agent_register)	 - Register agent with an upstream cluster
 

--- a/versioned_docs/version-0.10/cli/fleet-agent/fleet-agent.md
+++ b/versioned_docs/version-0.10/cli/fleet-agent/fleet-agent.md
@@ -28,6 +28,6 @@ fleet-agent [flags]
 
 ### SEE ALSO
 
-* [fleet-agent clusterstatus](./fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
-* [fleet-agent register](./fleet-agent_register)	 - Register agent with an upstream cluster
+* [fleet-agent clusterstatus](./fleet-agent/fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
+* [fleet-agent register](./fleet-agent/fleet-agent_register)	 - Register agent with an upstream cluster
 

--- a/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent.md
+++ b/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent.md
@@ -28,6 +28,6 @@ fleet-agent [flags]
 
 ### SEE ALSO
 
-* [fleet-agent clusterstatus](./fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
-* [fleet-agent register](./fleet-agent_register)	 - Register agent with an upstream cluster
+* [fleet-agent clusterstatus](./fleet-agent/fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
+* [fleet-agent register](./fleet-agent/fleet-agent_register)	 - Register agent with an upstream cluster
 

--- a/versioned_docs/version-0.12/cli/fleet-agent/fleet-agent.md
+++ b/versioned_docs/version-0.12/cli/fleet-agent/fleet-agent.md
@@ -28,6 +28,6 @@ fleet-agent [flags]
 
 ### SEE ALSO
 
-* [fleet-agent clusterstatus](fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
-* [fleet-agent register](fleet-agent_register)	 - Register agent with an upstream cluster
+* [fleet-agent clusterstatus](fleet-agent/fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
+* [fleet-agent register](fleet-agent/fleet-agent_register)	 - Register agent with an upstream cluster
 


### PR DESCRIPTION
Those links, previously broken, now properly redirect to subcommands.