### PR TITLE
Document HelmOps as experimental feature

### DIFF
--- a/docs/enableexperimental.md
+++ b/docs/enableexperimental.md
@@ -6,9 +6,15 @@ Enabling/disabling experimental features is done using extra environment variabl
 
 See also "[Configure Fleet Install Options in Rancher](./ref-configuration#configure-fleet-install-options-in-rancher)".
 
-## Enabling an experimental feature
+## Available experimental features
 
-At the moment we're writing this document, Fleet has OCI storage as an experimental feature.
+Right now Fleet supports the following experimental features:
+
+Fleet currently supports the following experimental features:
+* OCI storage: [`EXPERIMENTAL_OCI_STORAGE`](./oci-storage.md)
+* HelmOps: [`EXPERIMENTAL_HELM_OPS`](./helm-ops.md)
+
+## Enabling an experimental feature
 
 ### Enabling when installing Fleet stand-alone
 
@@ -31,9 +37,3 @@ The parameters are the same, but you have to add the `fleet.` prefix.
 --set-string fleet.extraEnv[0].name=EXPERIMENTAL_OCI_STORAGE \
 --set-string fleet.extraEnv[0].value=true \
 ```
-
-## Available experimental features
-
-Right now Fleet supports the following experimental features:
-
-* [`EXPERIMENTAL_OCI_STORAGE`](./oci-storage.md)

--- a/docs/helm-ops.md
+++ b/docs/helm-ops.md
@@ -1,0 +1,49 @@
+# HelmOps
+
+HelmOps is a simplified way of creating bundles by directly pointing to a Helm repository or to an OCI registry, without
+needing to set up a git repository.
+
+It is currently an experimental feature.
+
+## Summary
+
+When a `GitRepo` resource is created, Fleet monitors a git repository, creating one or more bundles from paths specified
+in the `GitRepo`, following a GitOps, or git-driven, approach to continuous deployment. This requires a git repository
+to be available, possibly containing `fleet.yaml` or other configuration files.
+
+HelmOps, on the other hand, enables a `HelmOp` resource to be created, with similar options to those available in a
+`GitRepo` resource and/or in a `fleet.yaml` file for targeting bundles to clusters, configuring chart values, etc.
+
+The Fleet HelmOps controller will create lightweight bundles, pointing to referenced Helm charts, without downloading
+them.
+However, it will resolve chart versions, for instance if a wildcard or empty version is specified, to ensure that the
+same, and latest, version of a chart is deployed to all targeted downstream clusters.
+
+When using this feature, Helm charts are downloaded from downstream clusters, which must therefore have access to Helm
+registries.
+
+## Creating a HelmOp resource
+
+A `HelmOp` resource can be created as follows to start deploying Helm charts directly:
+
+```yaml
+apiVersion: fleet.cattle.io/v1alpha1
+kind: HelmOp
+metadata:
+  name: my-awesome-helmop
+  namespace: "fleet-local"
+spec:
+  helm:
+    releaseName: my-fantastic-chart
+    repo: https://foo.bar/baz
+    chart: fantastic-chart
+    version: ''
+  namespace: that-amazing-namespace
+  helmSecretName: my-top-secret-helm-access
+  insecureSkipTLSVerify: false
+```
+
+For private charts, this requires a Helm access secret (referenced by field `helmSecretName`) to be created in the same
+namespace as the `HelmOp` resource.
+The Fleet HelmOps controller will take care of copying that secret to targeted downstream clusters, enabling the Fleet
+agent to access the registry.

--- a/sidebars.js
+++ b/sidebars.js
@@ -101,6 +101,7 @@ module.exports = {
       items:[
         'enableexperimental',
         'oci-storage',
+        'helm-ops',
       ],
     },
   ],


### PR DESCRIPTION
This provides basic information around the feature, why it exists, and how to make use of it.

Refers to https://github.com/rancher/fleet/issues/3435