### PR TITLE
Updating Missing Sidebar Entries

### DIFF
--- a/versioned_sidebars/version-0.11-sidebars.json
+++ b/versioned_sidebars/version-0.11-sidebars.json
@@ -106,6 +106,10 @@
             },
             {
               "type": "doc",
+              "id": "cli/fleet-cli/fleet_gitcloner"
+            },
+            {
+              "type": "doc",
               "id": "cli/fleet-cli/fleet_target"
             },
             {

--- a/versioned_sidebars/version-0.9-sidebars.json
+++ b/versioned_sidebars/version-0.9-sidebars.json
@@ -101,6 +101,10 @@
                 },
                 {
                   "type": "doc",
+                  "id": "cli/fleet-cli/fleet_cleanup"
+                },
+                {
+                  "type": "doc",
                   "id": "cli/fleet-cli/fleet_test"
                 }
               ]


### PR DESCRIPTION
Updating missing sidebar entries for v0.11 and v0.9 CLI items: 'fleet gitcloner' and 'fleet cleanup'.