### PR TITLE
Remove empty chart field from OCI HelmOps chart example

### DIFF
--- a/docs/helm-ops.md
+++ b/docs/helm-ops.md
@@ -104,7 +104,6 @@ In this case, Helm options would be similar to this:
 ```yaml
   helm:
     repo: oci://foo.bar/baz
-    chart: ''        # can be omitted
     version: '1.2.3' # optional
 ```
 


### PR DESCRIPTION
The comment specifying that the `chart` field could be omitted when referencing an OCI chart might mislead readers into thinking that non-empty values would still be allowed.