### PR TITLE
Fix 0.13 links

### DIFF
--- a/docs/cli/fleet-controller/fleet-controller.md
+++ b/docs/cli/fleet-controller/fleet-controller.md
@@ -29,6 +29,6 @@ fleet-controller [flags]
 
 ### SEE ALSO
 
-* [fleet-controller agentmanagement](fleet-controller_agentmanagement)	 -
-* [fleet-controller cleanup](fleet-controller_cleanup)	 -
-* [fleet-controller gitjob](fleet-controller_gitjob)	 -
+* [fleet-controller agentmanagement](fleet-controller_agentmanagement.md)	 -
+* [fleet-controller cleanup](fleet-controller_cleanup.md)	 -
+* [fleet-controller gitjob](fleet-controller_gitjob.md)	 -

--- a/docs/ref-crds.md
+++ b/docs/ref-crds.md
@@ -97,7 +97,7 @@ When a GitRepo is scanned it will produce one or more bundles. Bundles are a col
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -108,7 +108,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | readyClusters | ReadyClusters is a string in the form \"%d/%d\", that describes the number of clusters that are ready vs. the number of clusters desired to be ready. | string | false |
 | state | State is a summary state for the bundle, calculated over the non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleList
 
@@ -119,7 +119,7 @@ BundleList contains a list of Bundle
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Bundle](#bundle) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -130,7 +130,7 @@ BundleList contains a list of Bundle
 | name | Name of the bundle. | string | false |
 | selector | Selector matching bundle's labels. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -142,7 +142,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | content | The content of the resource, can be compressed. | string | false |
 | encoding | Encoding is either empty or \"base64+gz\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -158,7 +158,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 | contentsId | ContentsID stores the contents id when deploying contents using an OCI registry. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -181,7 +181,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | observedGeneration | ObservedGeneration is the current generation of the bundle. | int64 | true |
 | resourcesSha256Sum | ResourcesSHA256Sum corresponds to the JSON serialization of the .Spec.Resources field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -199,7 +199,7 @@ BundleSummary contains the number of bundle deployments in each state and a list
 | desiredReady | DesiredReady is the number of bundle deployments that should be ready. | int | true |
 | nonReadyResources | NonReadyClusters is a list of states, which is filled for a bundle that is not ready. | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -216,7 +216,7 @@ BundleTarget declares clusters to deploy to. Fleet will merge the BundleDeployme
 | namespaceLabels | NamespaceLabels are labels that will be appended to the namespace created by Fleet. | map[string]string | false |
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -230,7 +230,7 @@ BundleTargetRestriction is used internally by Fleet and should not be modified. 
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -244,7 +244,7 @@ NonReadyResource contains information about a bundle that is not ready for a giv
 | modifiedStatus | ModifiedStatus lists the state for each modified resource. | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus | NonReadyStatus lists the state for each non-ready resource. | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -259,7 +259,7 @@ Partition defines a separate rollout strategy for a set of clusters.
 | clusterGroup | A cluster group name to include in this partition | string | false |
 | clusterGroupSelector | Selector matching cluster group labels to include in this partition | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -273,7 +273,7 @@ PartitionStatus is the status of a single rollout partition.
 | unavailable | Unavailable is the number of unavailable clusters in the partition. | int | false |
 | summary | Summary is a summary state for the partition, calculated over its non-ready resources. | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -286,7 +286,7 @@ ResourceKey lists resources, which will likely be deployed.
 | namespace | Namespace is the namespace of the resource. | string | false |
 | name | Name is the name of the resource. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -299,7 +299,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | autoPartitionSize | A number or percentage of how to automatically partition clusters if no specific partitioning strategy is configured. default: 25% | *intstr.IntOrString | false |
 | partitions | A list of definitions of partitions.  If any target clusters do not match the configuration they are added to partitions at the end following the autoPartitionSize. | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -311,7 +311,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -323,7 +323,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentList
 
@@ -334,7 +334,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleDeployment](#bundledeployment) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -358,7 +358,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 | deleteCRDResources | DeleteCRDResources deletes CRDs. Warning! this will also delete all your Custom Resources. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentResource
 
@@ -372,7 +372,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | name |  | string | false |
 | createdAt |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -389,7 +389,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | correctDrift | CorrectDrift specifies how drift correction should work. | *[CorrectDrift](#correctdrift) | false |
 | ociContents | OCIContents is true when this deployment's contents is stored in an oci registry | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -408,7 +408,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | syncGeneration |  | *int64 | false |
 | resources | Resources lists the metadata of resources that were deployed according to the helm release history. | \[\][BundleDeploymentResource](#bundledeploymentresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -423,7 +423,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | operations | Operations remove a JSON path from the resource. | \[\][Operation](#operation) | false |
 | jsonPointers | JSONPointers ignore diffs at a certain JSON path. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -434,7 +434,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -444,7 +444,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | ----- | ----------- | ------ | -------- |
 | comparePatches | ComparePatches match a resource and remove fields from the check for modifications. | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -470,7 +470,7 @@ HelmOptions for the deployment. For Helm-based bundles, all options can be used,
 | skipSchemaValidation | SkipSchemaValidation allows skipping schema validation against the chart values | bool | false |
 | disableDependencyUpdate | DisableDependencyUpdate allows skipping chart dependencies update | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -480,7 +480,7 @@ IgnoreOptions defines conditions to be ignored when monitoring the Bundle.
 | ----- | ----------- | ------ | -------- |
 | conditions | Conditions is a list of conditions to be ignored when monitoring the Bundle. | []map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -490,7 +490,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | dir | Dir points to a custom folder for kustomize resources. This folder must contain a kustomization.yaml file. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -500,7 +500,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | name | Name of a resource in the same namespace as the referent. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -517,7 +517,7 @@ ModifiedStatus is used to report the status of a resource that is modified. It i
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -532,7 +532,7 @@ NonReadyStatus is used to report the status of a resource that is not ready. It 
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -544,7 +544,7 @@ Operation of a ComparePatch, usually \"remove\".
 | path | Path is the JSON path to remove. | string | false |
 | value | Value is usually empty. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -555,7 +555,7 @@ Operation of a ComparePatch, usually \"remove\".
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -566,7 +566,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -576,7 +576,7 @@ YAMLOptions, if using raw YAML these are names that map to overlays/`{name}` fil
 | ----- | ----------- | ------ | -------- |
 | overlays | Overlays is a list of names that maps to folders in \"overlays/\". If you wish to customize the file ./subdir/resource.yaml then a file ./overlays/myoverlay/subdir/resource.yaml will replace the base file. A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -588,7 +588,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMappingList
 
@@ -599,7 +599,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleNamespaceMapping](#bundlenamespacemapping) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -610,7 +610,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | lastSeen | LastSeen is the last time the agent checked in to update the status of the cluster resource. | metav1.Time | true |
 | namespace | Namespace is the namespace of the agent deployment, e.g. \"cattle-fleet-system\". | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -622,7 +622,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -633,7 +633,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State of the cluster, either one of the bundle states, or \"WaitCheckIn\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterList
 
@@ -644,7 +644,7 @@ ClusterList contains a list of Cluster
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Cluster](#cluster) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -666,7 +666,7 @@ ClusterList contains a list of Cluster
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *corev1.ResourceRequirements | false |
 | hostNetwork | HostNetwork sets the agent StatefulSet to use hostNetwork: true setting. Allows for provisioning of network related bundles (CNI configuration). | *bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -698,7 +698,7 @@ ClusterList contains a list of Cluster
 | agent | AgentStatus contains information about the agent. | [AgentStatus](#agentstatus) | false |
 | garbageCollectionInterval | GarbageCollectionInterval determines how often agents clean up obsolete Helm releases. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -710,7 +710,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -722,7 +722,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State is a summary state for the cluster group, showing \"NotReady\" if there are non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupList
 
@@ -733,7 +733,7 @@ ClusterGroupList contains a list of ClusterGroup
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterGroup](#clustergroup) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -743,7 +743,7 @@ ClusterGroupList contains a list of ClusterGroup
 | ----- | ----------- | ------ | -------- |
 | selector | Selector is a label selector, used to select clusters for this group. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -759,7 +759,7 @@ ClusterGroupList contains a list of ClusterGroup
 | display | Display contains the number of ready, desiredready clusters and a summary state for the bundle's resources. | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts | ResourceCounts contains the number of resources in each state over all bundles in the cluster group. | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -771,7 +771,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationList
 
@@ -782,7 +782,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistration](#clusterregistration) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -794,7 +794,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clientRandom | ClientRandom is a random string that the agent generates. When fleet-controller grants a registration, it creates a registration secret with this string in the name. | string | false |
 | clusterLabels | ClusterLabels are copied to the cluster resource during the registration. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -805,7 +805,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clusterName | ClusterName is only set after the registration is being processed by fleet-controller. | string | false |
 | granted | Granted is set to true, if the request service account is present and its token secret exists. This happens directly before creating the registration secret, roles and rolebindings. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -817,7 +817,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenList
 
@@ -828,7 +828,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistrationToken](#clusterregistrationtoken) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -838,7 +838,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | ----- | ----------- | ------ | -------- |
 | ttl | TTL is the time to live for the token. It is used to calculate the expiration time. If the token expires, it will be deleted. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -849,7 +849,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | expires | Expires is the time when the token expires. | *metav1.Time | false |
 | secretName | SecretName is the name of the secret containing the token. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -861,7 +861,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | content | Content is a byte array, which contains the manifests of a bundle. The bundle resources are copied into the bundledeployment's content resource, so the downstream agent can deploy them. | []byte | false |
 | sha256sum | SHA256Sum of the Content field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ContentList
 
@@ -872,7 +872,7 @@ ContentList contains a list of Content
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Content](#content) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -884,7 +884,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CorrectDrift
 
@@ -896,7 +896,7 @@ CommitSpec specifies how to commit changes to the git repository
 | force | Force helm rollback with --force option will be used if true. This will try to recreate all resources in the release. | bool | false |
 | keepFailHistory | KeepFailHistory keeps track of failed rollbacks in the helm history. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepo
 
@@ -908,7 +908,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -921,7 +921,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | message | Message contains the relevant message from the deployment conditions. | string | false |
 | error | Error is true if a message is present. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoList
 
@@ -932,7 +932,7 @@ GitRepoList contains a list of GitRepo
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepo](#gitrepo) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -953,7 +953,7 @@ GitRepoResource contains metadata about the resources of a bundle.
 | message | Message is the first message from the PerClusterStates. | string | false |
 | perClusterState | PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources. | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -970,7 +970,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | unknown | Unknown is the number of resources in an unknown state. | int | true |
 | notReady | NotReady is the number of not ready resources. Resources are not ready if they do not match any other state. | int | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -1002,7 +1002,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | disablePolling | Disables git polling. When enabled only webhooks will be used. | bool | false |
 | ociRegistry | OCIRegistry specifies the OCI registry related parameters | *[OCIRegistrySpec](#ociregistryspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -1026,7 +1026,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | lastSyncedImageScanTime | LastSyncedImageScanTime is the time of the last image scan. | metav1.Time | false |
 | lastPollingTriggered | LastPollingTime is the last time the polling check was triggered | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -1040,7 +1040,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | clusterGroup | ClusterGroup is the name of a cluster group in the same namespace as the clusters. | string | false |
 | clusterGroupSelector | ClusterGroupSelector is a label selector to select cluster groups. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### OCIRegistrySpec
 
@@ -1053,7 +1053,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | basicHTTP | BasicHTTP uses HTTP connections to the OCI registry when enabled. | bool | false |
 | insecureSkipTLS | InsecureSkipTLS allows connections to OCI registry without certs when enabled. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -1068,7 +1068,7 @@ ResourcePerClusterState is generated for each non-ready resource of the bundles.
 | patch | Patch for modified resources. | *GenericMap | false |
 | clusterId | ClusterID is the id of the cluster. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -1084,7 +1084,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | allowedClientSecretNames | AllowedClientSecretNames is a list of client secret names that GitRepos are allowed to use. | []string | false |
 | allowedTargetNamespaces | AllowedTargetNamespaces restricts TargetNamespace to the given namespaces. If AllowedTargetNamespaces is set, TargetNamespace must be set. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestrictionList
 
@@ -1095,7 +1095,7 @@ GitRepoRestrictionList contains a list of GitRepoRestriction
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepoRestriction](#gitreporestriction) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -1105,7 +1105,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -1116,7 +1116,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -1128,7 +1128,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanList
 
@@ -1139,7 +1139,7 @@ ImageScanList contains a list of ImageScan
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ImageScan](#imagescan) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -1155,7 +1155,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -1171,7 +1171,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -1181,7 +1181,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### FleetYAML
 
@@ -1196,7 +1196,7 @@ FleetYAML is the top-level structure of the fleet.yaml file. The fleet.yaml file
 | imageScans | ImageScans are optional and used to update container image references in the git repo. | \[\][ImageScanYAML](#imagescanyaml) | false |
 | overrideTargets | OverrideTargets overrides targets that are defined in the GitRepo resource. If overrideTargets is provided the bundle will not inherit targets from the GitRepo. | \[\][GitTarget](#gittarget) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanYAML
 
@@ -1207,4 +1207,4 @@ ImageScanYAML is a single entry in the ImageScan list from fleet.yaml.
 | name | Name of the image scan. Unused. | string | false |
 | ImageScanSpec |  | [ImageScanSpec](#imagescanspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,6 +130,12 @@ module.exports = {
             '0.11': {
               banner: 'none',
             },
+            '0.12': {
+              banner: 'none',
+            },
+            '0.13': {
+              banner: 'none',
+            },
           },
         },
         blog: false, // Optional: disable the blog plugin

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,8 +5,9 @@ module.exports = {
   tagline: '',
   url: 'https://fleet.rancher.io',
   baseUrl: '/',
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenAnchors: 'throw',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',
   organizationName: 'rancher', // Usually your GitHub org/user name.
   projectName: 'fleet-docs', // Usually your repo name.

--- a/versioned_docs/version-0.10/cli/fleet-agent/fleet-agent_clusterstatus.md
+++ b/versioned_docs/version-0.10/cli/fleet-agent/fleet-agent_clusterstatus.md
@@ -23,5 +23,5 @@ fleet-agent clusterstatus [flags]
 
 ### SEE ALSO
 
-* [fleet-agent](./fleet-agent)	 -
+* [fleet-agent](./)	 -
 

--- a/versioned_docs/version-0.10/cli/fleet-agent/fleet-agent_register.md
+++ b/versioned_docs/version-0.10/cli/fleet-agent/fleet-agent_register.md
@@ -22,5 +22,5 @@ fleet-agent register [flags]
 
 ### SEE ALSO
 
-* [fleet-agent](./fleet-agent)	 -
+* [fleet-agent](./)	 -
 

--- a/versioned_docs/version-0.10/ref-crds.md
+++ b/versioned_docs/version-0.10/ref-crds.md
@@ -97,7 +97,7 @@ When a GitRepo is scanned it will produce one or more bundles. Bundles are a col
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -108,7 +108,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | readyClusters | ReadyClusters is a string in the form \"%d/%d\", that describes the number of clusters that are ready vs. the number of clusters desired to be ready. | string | false |
 | state | State is a summary state for the bundle, calculated over the non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleList
 
@@ -119,7 +119,7 @@ BundleList contains a list of Bundle
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Bundle](#bundle) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -130,7 +130,7 @@ BundleList contains a list of Bundle
 | name | Name of the bundle. | string | false |
 | selector | Selector matching bundle's labels. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -142,7 +142,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | content | The content of the resource, can be compressed. | string | false |
 | encoding | Encoding is either empty or \"base64+gz\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -158,7 +158,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 | contentsId | ContentsID stores the contents id when deploying contents using an OCI registry. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -181,7 +181,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | observedGeneration | ObservedGeneration is the current generation of the bundle. | int64 | true |
 | resourcesSha256Sum | ResourcesSHA256Sum corresponds to the JSON serialization of the .Spec.Resources field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -199,7 +199,7 @@ BundleSummary contains the number of bundle deployments in each state and a list
 | desiredReady | DesiredReady is the number of bundle deployments that should be ready. | int | true |
 | nonReadyResources | NonReadyClusters is a list of states, which is filled for a bundle that is not ready. | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -216,7 +216,7 @@ BundleTarget declares clusters to deploy to. Fleet will merge the BundleDeployme
 | namespaceLabels | NamespaceLabels are labels that will be appended to the namespace created by Fleet. | *map[string]string | false |
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | *map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -230,7 +230,7 @@ BundleTargetRestriction is used internally by Fleet and should not be modified. 
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -244,7 +244,7 @@ NonReadyResource contains information about a bundle that is not ready for a giv
 | modifiedStatus | ModifiedStatus lists the state for each modified resource. | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus | NonReadyStatus lists the state for each non-ready resource. | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -259,7 +259,7 @@ Partition defines a separate rollout strategy for a set of clusters.
 | clusterGroup | A cluster group name to include in this partition | string | false |
 | clusterGroupSelector | Selector matching cluster group labels to include in this partition | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -273,7 +273,7 @@ PartitionStatus is the status of a single rollout partition.
 | unavailable | Unavailable is the number of unavailable clusters in the partition. | int | false |
 | summary | Summary is a summary state for the partition, calculated over its non-ready resources. | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -286,7 +286,7 @@ ResourceKey lists resources, which will likely be deployed.
 | namespace | Namespace is the namespace of the resource. | string | false |
 | name | Name is the name of the resource. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -299,7 +299,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | autoPartitionSize | A number or percentage of how to automatically partition clusters if no specific partitioning strategy is configured. default: 25% | *intstr.IntOrString | false |
 | partitions | A list of definitions of partitions.  If any target clusters do not match the configuration they are added to partitions at the end following the autoPartitionSize. | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -311,7 +311,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -323,7 +323,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentList
 
@@ -334,7 +334,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleDeployment](#bundledeployment) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -358,7 +358,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | *map[string]string | false |
 | deleteCRDResources | DeleteCRDResources deletes CRDs. Warning! this will also delete all your Custom Resources. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentResource
 
@@ -372,7 +372,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | name |  | string | false |
 | createdAt |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -389,7 +389,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | correctDrift | CorrectDrift specifies how drift correction should work. | *[CorrectDrift](#correctdrift) | false |
 | ociContents | OCIContents is true when this deployment's contents is stored in an oci registry | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -408,7 +408,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | syncGeneration |  | *int64 | false |
 | resources | Resources lists the metadata of resources that were deployed according to the helm release history. | \[\][BundleDeploymentResource](#bundledeploymentresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -423,7 +423,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | operations | Operations remove a JSON path from the resource. | \[\][Operation](#operation) | false |
 | jsonPointers | JSONPointers ignore diffs at a certain JSON path. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -434,7 +434,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -444,7 +444,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | ----- | ----------- | ------ | -------- |
 | comparePatches | ComparePatches match a resource and remove fields from the check for modifications. | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -470,7 +470,7 @@ HelmOptions for the deployment. For Helm-based bundles, all options can be used,
 | skipSchemaValidation | SkipSchemaValidation allows skipping schema validation against the chart values | bool | false |
 | disableDependencyUpdate | DisableDependencyUpdate allows skipping chart dependencies update | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -480,7 +480,7 @@ IgnoreOptions defines conditions to be ignored when monitoring the Bundle.
 | ----- | ----------- | ------ | -------- |
 | conditions | Conditions is a list of conditions to be ignored when monitoring the Bundle. | []map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -490,7 +490,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | dir | Dir points to a custom folder for kustomize resources. This folder must contain a kustomization.yaml file. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -500,7 +500,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | name | Name of a resource in the same namespace as the referent. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -516,7 +516,7 @@ ModifiedStatus is used to report the status of a resource that is modified. It i
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -531,7 +531,7 @@ NonReadyStatus is used to report the status of a resource that is not ready. It 
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -543,7 +543,7 @@ Operation of a ComparePatch, usually \"remove\".
 | path | Path is the JSON path to remove. | string | false |
 | value | Value is usually empty. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -554,7 +554,7 @@ Operation of a ComparePatch, usually \"remove\".
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -565,7 +565,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -575,7 +575,7 @@ YAMLOptions, if using raw YAML these are names that map to overlays/`{name}` fil
 | ----- | ----------- | ------ | -------- |
 | overlays | Overlays is a list of names that maps to folders in \"overlays/\". If you wish to customize the file ./subdir/resource.yaml then a file ./overlays/myoverlay/subdir/resource.yaml will replace the base file. A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -587,7 +587,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMappingList
 
@@ -598,7 +598,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleNamespaceMapping](#bundlenamespacemapping) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -609,7 +609,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | lastSeen | LastSeen is the last time the agent checked in to update the status of the cluster resource. | metav1.Time | true |
 | namespace | Namespace is the namespace of the agent deployment, e.g. \"cattle-fleet-system\". | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -621,7 +621,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -632,7 +632,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State of the cluster, either one of the bundle states, or \"WaitCheckIn\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterList
 
@@ -643,7 +643,7 @@ ClusterList contains a list of Cluster
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Cluster](#cluster) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -665,7 +665,7 @@ ClusterList contains a list of Cluster
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *corev1.ResourceRequirements | false |
 | hostNetwork | HostNetwork sets the agent StatefulSet to use hostNetwork: true setting. Allows for provisioning of network related bundles (CNI configuration). | *bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -697,7 +697,7 @@ ClusterList contains a list of Cluster
 | agent | AgentStatus contains information about the agent. | [AgentStatus](#agentstatus) | false |
 | garbageCollectionInterval | GarbageCollectionInterval determines how often agents clean up obsolete Helm releases. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -709,7 +709,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -721,7 +721,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State is a summary state for the cluster group, showing \"NotReady\" if there are non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupList
 
@@ -732,7 +732,7 @@ ClusterGroupList contains a list of ClusterGroup
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterGroup](#clustergroup) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -742,7 +742,7 @@ ClusterGroupList contains a list of ClusterGroup
 | ----- | ----------- | ------ | -------- |
 | selector | Selector is a label selector, used to select clusters for this group. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -758,7 +758,7 @@ ClusterGroupList contains a list of ClusterGroup
 | display | Display contains the number of ready, desiredready clusters and a summary state for the bundle's resources. | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts | ResourceCounts contains the number of resources in each state over all bundles in the cluster group. | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -770,7 +770,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationList
 
@@ -781,7 +781,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistration](#clusterregistration) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -793,7 +793,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clientRandom | ClientRandom is a random string that the agent generates. When fleet-controller grants a registration, it creates a registration secret with this string in the name. | string | false |
 | clusterLabels | ClusterLabels are copied to the cluster resource during the registration. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -804,7 +804,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clusterName | ClusterName is only set after the registration is being processed by fleet-controller. | string | false |
 | granted | Granted is set to true, if the request service account is present and its token secret exists. This happens directly before creating the registration secret, roles and rolebindings. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -816,7 +816,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenList
 
@@ -827,7 +827,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistrationToken](#clusterregistrationtoken) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -837,7 +837,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | ----- | ----------- | ------ | -------- |
 | ttl | TTL is the time to live for the token. It is used to calculate the expiration time. If the token expires, it will be deleted. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -848,7 +848,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | expires | Expires is the time when the token expires. | *metav1.Time | false |
 | secretName | SecretName is the name of the secret containing the token. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -860,7 +860,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | content | Content is a byte array, which contains the manifests of a bundle. The bundle resources are copied into the bundledeployment's content resource, so the downstream agent can deploy them. | []byte | false |
 | sha256sum | SHA256Sum of the Content field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ContentList
 
@@ -871,7 +871,7 @@ ContentList contains a list of Content
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Content](#content) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -883,7 +883,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CorrectDrift
 
@@ -895,7 +895,7 @@ CommitSpec specifies how to commit changes to the git repository
 | force | Force helm rollback with --force option will be used if true. This will try to recreate all resources in the release. | bool | false |
 | keepFailHistory | KeepFailHistory keeps track of failed rollbacks in the helm history. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepo
 
@@ -907,7 +907,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -920,7 +920,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | message | Message contains the relevant message from the deployment conditions. | string | false |
 | error | Error is true if a message is present. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoList
 
@@ -931,7 +931,7 @@ GitRepoList contains a list of GitRepo
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepo](#gitrepo) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -952,7 +952,7 @@ GitRepoResource contains metadata about the resources of a bundle.
 | message | Message is the first message from the PerClusterStates. | string | false |
 | perClusterState | PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources. | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -969,7 +969,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | unknown | Unknown is the number of resources in an unknown state. | int | true |
 | notReady | NotReady is the number of not ready resources. Resources are not ready if they do not match any other state. | int | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -1001,7 +1001,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | disablePolling | Disables git polling. When enabled only webhooks will be used. | bool | false |
 | ociRegistry | OCIRegistry specifies the OCI registry related parameters | *[OCIRegistrySpec](#ociregistryspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -1025,7 +1025,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | lastSyncedImageScanTime | LastSyncedImageScanTime is the time of the last image scan. | metav1.Time | false |
 | lastPollingTriggered | LastPollingTime is the last time the polling check was triggered | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -1039,7 +1039,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | clusterGroup | ClusterGroup is the name of a cluster group in the same namespace as the clusters. | string | false |
 | clusterGroupSelector | ClusterGroupSelector is a label selector to select cluster groups. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### OCIRegistrySpec
 
@@ -1052,7 +1052,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | basicHTTP | BasicHTTP uses HTTP connections to the OCI registry when enabled. | bool | false |
 | insecureSkipTLS | InsecureSkipTLS allows connections to OCI registry without certs when enabled. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -1067,7 +1067,7 @@ ResourcePerClusterState is generated for each non-ready resource of the bundles.
 | patch | Patch for modified resources. | *GenericMap | false |
 | clusterId | ClusterID is the id of the cluster. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -1083,7 +1083,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | allowedClientSecretNames | AllowedClientSecretNames is a list of client secret names that GitRepos are allowed to use. | []string | false |
 | allowedTargetNamespaces | AllowedTargetNamespaces restricts TargetNamespace to the given namespaces. If AllowedTargetNamespaces is set, TargetNamespace must be set. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestrictionList
 
@@ -1094,7 +1094,7 @@ GitRepoRestrictionList contains a list of GitRepoRestriction
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepoRestriction](#gitreporestriction) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -1104,7 +1104,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -1115,7 +1115,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -1127,7 +1127,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanList
 
@@ -1138,7 +1138,7 @@ ImageScanList contains a list of ImageScan
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ImageScan](#imagescan) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -1154,7 +1154,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -1170,7 +1170,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -1180,7 +1180,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### FleetYAML
 
@@ -1195,7 +1195,7 @@ FleetYAML is the top-level structure of the fleet.yaml file. The fleet.yaml file
 | imageScans | ImageScans are optional and used to update container image references in the git repo. | \[\][ImageScanYAML](#imagescanyaml) | false |
 | overrideTargets | OverrideTargets overrides targets that are defined in the GitRepo resource. If overrideTargets is provided the bundle will not inherit targets from the GitRepo. | \[\][GitTarget](#gittarget) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanYAML
 
@@ -1206,4 +1206,4 @@ ImageScanYAML is a single entry in the ImageScan list from fleet.yaml.
 | name | Name of the image scan. Unused. | string | false |
 | ImageScanSpec |  | [ImageScanSpec](#imagescanspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)

--- a/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent.md
+++ b/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent.md
@@ -28,6 +28,6 @@ fleet-agent [flags]
 
 ### SEE ALSO
 
-* [fleet-agent clusterstatus](./fleet-agent/fleet-agent_clusterstatus)	 - Continuously report resource status to the upstream cluster
-* [fleet-agent register](./fleet-agent/fleet-agent_register)	 - Register agent with an upstream cluster
+* [fleet-agent clusterstatus](fleet-agent_clusterstatus.md)	 - Continuously report resource status to the upstream cluster
+* [fleet-agent register](fleet-agent_register.md)	 - Register agent with an upstream cluster
 

--- a/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent_clusterstatus.md
+++ b/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent_clusterstatus.md
@@ -23,5 +23,5 @@ fleet-agent clusterstatus [flags]
 
 ### SEE ALSO
 
-* [fleet-agent](./fleet-agent)	 -
+* [fleet-agent](./)	 -
 

--- a/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent_register.md
+++ b/versioned_docs/version-0.11/cli/fleet-agent/fleet-agent_register.md
@@ -22,5 +22,5 @@ fleet-agent register [flags]
 
 ### SEE ALSO
 
-* [fleet-agent](./fleet-agent)	 -
+* [fleet-agent](./)	 -
 

--- a/versioned_docs/version-0.11/ref-crds.md
+++ b/versioned_docs/version-0.11/ref-crds.md
@@ -97,7 +97,7 @@ When a GitRepo is scanned it will produce one or more bundles. Bundles are a col
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -108,7 +108,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | readyClusters | ReadyClusters is a string in the form \"%d/%d\", that describes the number of clusters that are ready vs. the number of clusters desired to be ready. | string | false |
 | state | State is a summary state for the bundle, calculated over the non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleList
 
@@ -119,7 +119,7 @@ BundleList contains a list of Bundle
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Bundle](#bundle) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -130,7 +130,7 @@ BundleList contains a list of Bundle
 | name | Name of the bundle. | string | false |
 | selector | Selector matching bundle's labels. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -142,7 +142,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | content | The content of the resource, can be compressed. | string | false |
 | encoding | Encoding is either empty or \"base64+gz\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -158,7 +158,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 | contentsId | ContentsID stores the contents id when deploying contents using an OCI registry. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -181,7 +181,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | observedGeneration | ObservedGeneration is the current generation of the bundle. | int64 | true |
 | resourcesSha256Sum | ResourcesSHA256Sum corresponds to the JSON serialization of the .Spec.Resources field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -199,7 +199,7 @@ BundleSummary contains the number of bundle deployments in each state and a list
 | desiredReady | DesiredReady is the number of bundle deployments that should be ready. | int | true |
 | nonReadyResources | NonReadyClusters is a list of states, which is filled for a bundle that is not ready. | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -216,7 +216,7 @@ BundleTarget declares clusters to deploy to. Fleet will merge the BundleDeployme
 | namespaceLabels | NamespaceLabels are labels that will be appended to the namespace created by Fleet. | map[string]string | false |
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -230,7 +230,7 @@ BundleTargetRestriction is used internally by Fleet and should not be modified. 
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -244,7 +244,7 @@ NonReadyResource contains information about a bundle that is not ready for a giv
 | modifiedStatus | ModifiedStatus lists the state for each modified resource. | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus | NonReadyStatus lists the state for each non-ready resource. | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -259,7 +259,7 @@ Partition defines a separate rollout strategy for a set of clusters.
 | clusterGroup | A cluster group name to include in this partition | string | false |
 | clusterGroupSelector | Selector matching cluster group labels to include in this partition | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -273,7 +273,7 @@ PartitionStatus is the status of a single rollout partition.
 | unavailable | Unavailable is the number of unavailable clusters in the partition. | int | false |
 | summary | Summary is a summary state for the partition, calculated over its non-ready resources. | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -286,7 +286,7 @@ ResourceKey lists resources, which will likely be deployed.
 | namespace | Namespace is the namespace of the resource. | string | false |
 | name | Name is the name of the resource. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -299,7 +299,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | autoPartitionSize | A number or percentage of how to automatically partition clusters if no specific partitioning strategy is configured. default: 25% | *intstr.IntOrString | false |
 | partitions | A list of definitions of partitions.  If any target clusters do not match the configuration they are added to partitions at the end following the autoPartitionSize. | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -311,7 +311,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -323,7 +323,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentList
 
@@ -334,7 +334,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleDeployment](#bundledeployment) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -358,7 +358,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 | deleteCRDResources | DeleteCRDResources deletes CRDs. Warning! this will also delete all your Custom Resources. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentResource
 
@@ -372,7 +372,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | name |  | string | false |
 | createdAt |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -389,7 +389,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | correctDrift | CorrectDrift specifies how drift correction should work. | *[CorrectDrift](#correctdrift) | false |
 | ociContents | OCIContents is true when this deployment's contents is stored in an oci registry | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -408,7 +408,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | syncGeneration |  | *int64 | false |
 | resources | Resources lists the metadata of resources that were deployed according to the helm release history. | \[\][BundleDeploymentResource](#bundledeploymentresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -423,7 +423,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | operations | Operations remove a JSON path from the resource. | \[\][Operation](#operation) | false |
 | jsonPointers | JSONPointers ignore diffs at a certain JSON path. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -434,7 +434,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -444,7 +444,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | ----- | ----------- | ------ | -------- |
 | comparePatches | ComparePatches match a resource and remove fields from the check for modifications. | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -470,7 +470,7 @@ HelmOptions for the deployment. For Helm-based bundles, all options can be used,
 | skipSchemaValidation | SkipSchemaValidation allows skipping schema validation against the chart values | bool | false |
 | disableDependencyUpdate | DisableDependencyUpdate allows skipping chart dependencies update | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -480,7 +480,7 @@ IgnoreOptions defines conditions to be ignored when monitoring the Bundle.
 | ----- | ----------- | ------ | -------- |
 | conditions | Conditions is a list of conditions to be ignored when monitoring the Bundle. | []map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -490,7 +490,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | dir | Dir points to a custom folder for kustomize resources. This folder must contain a kustomization.yaml file. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -500,7 +500,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | name | Name of a resource in the same namespace as the referent. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -517,7 +517,7 @@ ModifiedStatus is used to report the status of a resource that is modified. It i
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -532,7 +532,7 @@ NonReadyStatus is used to report the status of a resource that is not ready. It 
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -544,7 +544,7 @@ Operation of a ComparePatch, usually \"remove\".
 | path | Path is the JSON path to remove. | string | false |
 | value | Value is usually empty. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -555,7 +555,7 @@ Operation of a ComparePatch, usually \"remove\".
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -566,7 +566,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -576,7 +576,7 @@ YAMLOptions, if using raw YAML these are names that map to overlays/`{name}` fil
 | ----- | ----------- | ------ | -------- |
 | overlays | Overlays is a list of names that maps to folders in \"overlays/\". If you wish to customize the file ./subdir/resource.yaml then a file ./overlays/myoverlay/subdir/resource.yaml will replace the base file. A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -588,7 +588,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMappingList
 
@@ -599,7 +599,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleNamespaceMapping](#bundlenamespacemapping) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -610,7 +610,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | lastSeen | LastSeen is the last time the agent checked in to update the status of the cluster resource. | metav1.Time | true |
 | namespace | Namespace is the namespace of the agent deployment, e.g. \"cattle-fleet-system\". | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -622,7 +622,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -633,7 +633,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State of the cluster, either one of the bundle states, or \"WaitCheckIn\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterList
 
@@ -644,7 +644,7 @@ ClusterList contains a list of Cluster
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Cluster](#cluster) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -666,7 +666,7 @@ ClusterList contains a list of Cluster
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *corev1.ResourceRequirements | false |
 | hostNetwork | HostNetwork sets the agent StatefulSet to use hostNetwork: true setting. Allows for provisioning of network related bundles (CNI configuration). | *bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -698,7 +698,7 @@ ClusterList contains a list of Cluster
 | agent | AgentStatus contains information about the agent. | [AgentStatus](#agentstatus) | false |
 | garbageCollectionInterval | GarbageCollectionInterval determines how often agents clean up obsolete Helm releases. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -710,7 +710,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -722,7 +722,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State is a summary state for the cluster group, showing \"NotReady\" if there are non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupList
 
@@ -733,7 +733,7 @@ ClusterGroupList contains a list of ClusterGroup
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterGroup](#clustergroup) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -743,7 +743,7 @@ ClusterGroupList contains a list of ClusterGroup
 | ----- | ----------- | ------ | -------- |
 | selector | Selector is a label selector, used to select clusters for this group. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -759,7 +759,7 @@ ClusterGroupList contains a list of ClusterGroup
 | display | Display contains the number of ready, desiredready clusters and a summary state for the bundle's resources. | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts | ResourceCounts contains the number of resources in each state over all bundles in the cluster group. | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -771,7 +771,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationList
 
@@ -782,7 +782,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistration](#clusterregistration) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -794,7 +794,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clientRandom | ClientRandom is a random string that the agent generates. When fleet-controller grants a registration, it creates a registration secret with this string in the name. | string | false |
 | clusterLabels | ClusterLabels are copied to the cluster resource during the registration. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -805,7 +805,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clusterName | ClusterName is only set after the registration is being processed by fleet-controller. | string | false |
 | granted | Granted is set to true, if the request service account is present and its token secret exists. This happens directly before creating the registration secret, roles and rolebindings. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -817,7 +817,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenList
 
@@ -828,7 +828,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistrationToken](#clusterregistrationtoken) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -838,7 +838,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | ----- | ----------- | ------ | -------- |
 | ttl | TTL is the time to live for the token. It is used to calculate the expiration time. If the token expires, it will be deleted. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -849,7 +849,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | expires | Expires is the time when the token expires. | *metav1.Time | false |
 | secretName | SecretName is the name of the secret containing the token. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -861,7 +861,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | content | Content is a byte array, which contains the manifests of a bundle. The bundle resources are copied into the bundledeployment's content resource, so the downstream agent can deploy them. | []byte | false |
 | sha256sum | SHA256Sum of the Content field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ContentList
 
@@ -872,7 +872,7 @@ ContentList contains a list of Content
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Content](#content) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -884,7 +884,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CorrectDrift
 
@@ -896,7 +896,7 @@ CommitSpec specifies how to commit changes to the git repository
 | force | Force helm rollback with --force option will be used if true. This will try to recreate all resources in the release. | bool | false |
 | keepFailHistory | KeepFailHistory keeps track of failed rollbacks in the helm history. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepo
 
@@ -908,7 +908,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -921,7 +921,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | message | Message contains the relevant message from the deployment conditions. | string | false |
 | error | Error is true if a message is present. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoList
 
@@ -932,7 +932,7 @@ GitRepoList contains a list of GitRepo
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepo](#gitrepo) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -953,7 +953,7 @@ GitRepoResource contains metadata about the resources of a bundle.
 | message | Message is the first message from the PerClusterStates. | string | false |
 | perClusterState | PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources. | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -970,7 +970,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | unknown | Unknown is the number of resources in an unknown state. | int | true |
 | notReady | NotReady is the number of not ready resources. Resources are not ready if they do not match any other state. | int | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -1002,7 +1002,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | disablePolling | Disables git polling. When enabled only webhooks will be used. | bool | false |
 | ociRegistry | OCIRegistry specifies the OCI registry related parameters | *[OCIRegistrySpec](#ociregistryspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -1026,7 +1026,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | lastSyncedImageScanTime | LastSyncedImageScanTime is the time of the last image scan. | metav1.Time | false |
 | lastPollingTriggered | LastPollingTime is the last time the polling check was triggered | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -1040,7 +1040,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | clusterGroup | ClusterGroup is the name of a cluster group in the same namespace as the clusters. | string | false |
 | clusterGroupSelector | ClusterGroupSelector is a label selector to select cluster groups. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### OCIRegistrySpec
 
@@ -1053,7 +1053,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | basicHTTP | BasicHTTP uses HTTP connections to the OCI registry when enabled. | bool | false |
 | insecureSkipTLS | InsecureSkipTLS allows connections to OCI registry without certs when enabled. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -1068,7 +1068,7 @@ ResourcePerClusterState is generated for each non-ready resource of the bundles.
 | patch | Patch for modified resources. | *GenericMap | false |
 | clusterId | ClusterID is the id of the cluster. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -1084,7 +1084,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | allowedClientSecretNames | AllowedClientSecretNames is a list of client secret names that GitRepos are allowed to use. | []string | false |
 | allowedTargetNamespaces | AllowedTargetNamespaces restricts TargetNamespace to the given namespaces. If AllowedTargetNamespaces is set, TargetNamespace must be set. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestrictionList
 
@@ -1095,7 +1095,7 @@ GitRepoRestrictionList contains a list of GitRepoRestriction
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepoRestriction](#gitreporestriction) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -1105,7 +1105,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -1116,7 +1116,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -1128,7 +1128,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanList
 
@@ -1139,7 +1139,7 @@ ImageScanList contains a list of ImageScan
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ImageScan](#imagescan) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -1155,7 +1155,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -1171,7 +1171,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -1181,7 +1181,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### FleetYAML
 
@@ -1196,7 +1196,7 @@ FleetYAML is the top-level structure of the fleet.yaml file. The fleet.yaml file
 | imageScans | ImageScans are optional and used to update container image references in the git repo. | \[\][ImageScanYAML](#imagescanyaml) | false |
 | overrideTargets | OverrideTargets overrides targets that are defined in the GitRepo resource. If overrideTargets is provided the bundle will not inherit targets from the GitRepo. | \[\][GitTarget](#gittarget) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanYAML
 
@@ -1207,4 +1207,4 @@ ImageScanYAML is a single entry in the ImageScan list from fleet.yaml.
 | name | Name of the image scan. Unused. | string | false |
 | ImageScanSpec |  | [ImageScanSpec](#imagescanspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)

--- a/versioned_docs/version-0.12/cli/fleet-controller/fleet-controller.md
+++ b/versioned_docs/version-0.12/cli/fleet-controller/fleet-controller.md
@@ -29,6 +29,6 @@ fleet-controller [flags]
 
 ### SEE ALSO
 
-* [fleet-controller agentmanagement](fleet-controller_agentmanagement)	 -
-* [fleet-controller cleanup](fleet-controller_cleanup)	 -
-* [fleet-controller gitjob](fleet-controller_gitjob)	 -
+* [fleet-controller agentmanagement](fleet-controller_agentmanagement.md)	 -
+* [fleet-controller cleanup](fleet-controller_cleanup.md)	 -
+* [fleet-controller gitjob](fleet-controller_gitjob.md)	 -

--- a/versioned_docs/version-0.12/ref-crds.md
+++ b/versioned_docs/version-0.12/ref-crds.md
@@ -97,7 +97,7 @@ When a GitRepo is scanned it will produce one or more bundles. Bundles are a col
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -108,7 +108,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | readyClusters | ReadyClusters is a string in the form \"%d/%d\", that describes the number of clusters that are ready vs. the number of clusters desired to be ready. | string | false |
 | state | State is a summary state for the bundle, calculated over the non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleList
 
@@ -119,7 +119,7 @@ BundleList contains a list of Bundle
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Bundle](#bundle) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -130,7 +130,7 @@ BundleList contains a list of Bundle
 | name | Name of the bundle. | string | false |
 | selector | Selector matching bundle's labels. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -142,7 +142,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | content | The content of the resource, can be compressed. | string | false |
 | encoding | Encoding is either empty or \"base64+gz\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -158,7 +158,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 | contentsId | ContentsID stores the contents id when deploying contents using an OCI registry. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -181,7 +181,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | observedGeneration | ObservedGeneration is the current generation of the bundle. | int64 | true |
 | resourcesSha256Sum | ResourcesSHA256Sum corresponds to the JSON serialization of the .Spec.Resources field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -199,7 +199,7 @@ BundleSummary contains the number of bundle deployments in each state and a list
 | desiredReady | DesiredReady is the number of bundle deployments that should be ready. | int | true |
 | nonReadyResources | NonReadyClusters is a list of states, which is filled for a bundle that is not ready. | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -216,7 +216,7 @@ BundleTarget declares clusters to deploy to. Fleet will merge the BundleDeployme
 | namespaceLabels | NamespaceLabels are labels that will be appended to the namespace created by Fleet. | map[string]string | false |
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -230,7 +230,7 @@ BundleTargetRestriction is used internally by Fleet and should not be modified. 
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -244,7 +244,7 @@ NonReadyResource contains information about a bundle that is not ready for a giv
 | modifiedStatus | ModifiedStatus lists the state for each modified resource. | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus | NonReadyStatus lists the state for each non-ready resource. | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -259,7 +259,7 @@ Partition defines a separate rollout strategy for a set of clusters.
 | clusterGroup | A cluster group name to include in this partition | string | false |
 | clusterGroupSelector | Selector matching cluster group labels to include in this partition | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -273,7 +273,7 @@ PartitionStatus is the status of a single rollout partition.
 | unavailable | Unavailable is the number of unavailable clusters in the partition. | int | false |
 | summary | Summary is a summary state for the partition, calculated over its non-ready resources. | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -286,7 +286,7 @@ ResourceKey lists resources, which will likely be deployed.
 | namespace | Namespace is the namespace of the resource. | string | false |
 | name | Name is the name of the resource. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -299,7 +299,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | autoPartitionSize | A number or percentage of how to automatically partition clusters if no specific partitioning strategy is configured. default: 25% | *intstr.IntOrString | false |
 | partitions | A list of definitions of partitions.  If any target clusters do not match the configuration they are added to partitions at the end following the autoPartitionSize. | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -311,7 +311,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -323,7 +323,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentList
 
@@ -334,7 +334,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleDeployment](#bundledeployment) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -358,7 +358,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 | deleteCRDResources | DeleteCRDResources deletes CRDs. Warning! this will also delete all your Custom Resources. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentResource
 
@@ -372,7 +372,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | name |  | string | false |
 | createdAt |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -389,7 +389,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | correctDrift | CorrectDrift specifies how drift correction should work. | *[CorrectDrift](#correctdrift) | false |
 | ociContents | OCIContents is true when this deployment's contents is stored in an oci registry | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -408,7 +408,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | syncGeneration |  | *int64 | false |
 | resources | Resources lists the metadata of resources that were deployed according to the helm release history. | \[\][BundleDeploymentResource](#bundledeploymentresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -423,7 +423,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | operations | Operations remove a JSON path from the resource. | \[\][Operation](#operation) | false |
 | jsonPointers | JSONPointers ignore diffs at a certain JSON path. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -434,7 +434,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -444,7 +444,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | ----- | ----------- | ------ | -------- |
 | comparePatches | ComparePatches match a resource and remove fields from the check for modifications. | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -470,7 +470,7 @@ HelmOptions for the deployment. For Helm-based bundles, all options can be used,
 | skipSchemaValidation | SkipSchemaValidation allows skipping schema validation against the chart values | bool | false |
 | disableDependencyUpdate | DisableDependencyUpdate allows skipping chart dependencies update | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -480,7 +480,7 @@ IgnoreOptions defines conditions to be ignored when monitoring the Bundle.
 | ----- | ----------- | ------ | -------- |
 | conditions | Conditions is a list of conditions to be ignored when monitoring the Bundle. | []map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -490,7 +490,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | dir | Dir points to a custom folder for kustomize resources. This folder must contain a kustomization.yaml file. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -500,7 +500,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | name | Name of a resource in the same namespace as the referent. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -517,7 +517,7 @@ ModifiedStatus is used to report the status of a resource that is modified. It i
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -532,7 +532,7 @@ NonReadyStatus is used to report the status of a resource that is not ready. It 
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -544,7 +544,7 @@ Operation of a ComparePatch, usually \"remove\".
 | path | Path is the JSON path to remove. | string | false |
 | value | Value is usually empty. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -555,7 +555,7 @@ Operation of a ComparePatch, usually \"remove\".
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -566,7 +566,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -576,7 +576,7 @@ YAMLOptions, if using raw YAML these are names that map to overlays/`{name}` fil
 | ----- | ----------- | ------ | -------- |
 | overlays | Overlays is a list of names that maps to folders in \"overlays/\". If you wish to customize the file ./subdir/resource.yaml then a file ./overlays/myoverlay/subdir/resource.yaml will replace the base file. A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -588,7 +588,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMappingList
 
@@ -599,7 +599,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleNamespaceMapping](#bundlenamespacemapping) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -610,7 +610,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | lastSeen | LastSeen is the last time the agent checked in to update the status of the cluster resource. | metav1.Time | true |
 | namespace | Namespace is the namespace of the agent deployment, e.g. \"cattle-fleet-system\". | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -622,7 +622,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -633,7 +633,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State of the cluster, either one of the bundle states, or \"WaitCheckIn\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterList
 
@@ -644,7 +644,7 @@ ClusterList contains a list of Cluster
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Cluster](#cluster) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -666,7 +666,7 @@ ClusterList contains a list of Cluster
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *corev1.ResourceRequirements | false |
 | hostNetwork | HostNetwork sets the agent StatefulSet to use hostNetwork: true setting. Allows for provisioning of network related bundles (CNI configuration). | *bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -698,7 +698,7 @@ ClusterList contains a list of Cluster
 | agent | AgentStatus contains information about the agent. | [AgentStatus](#agentstatus) | false |
 | garbageCollectionInterval | GarbageCollectionInterval determines how often agents clean up obsolete Helm releases. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -710,7 +710,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -722,7 +722,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State is a summary state for the cluster group, showing \"NotReady\" if there are non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupList
 
@@ -733,7 +733,7 @@ ClusterGroupList contains a list of ClusterGroup
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterGroup](#clustergroup) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -743,7 +743,7 @@ ClusterGroupList contains a list of ClusterGroup
 | ----- | ----------- | ------ | -------- |
 | selector | Selector is a label selector, used to select clusters for this group. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -759,7 +759,7 @@ ClusterGroupList contains a list of ClusterGroup
 | display | Display contains the number of ready, desiredready clusters and a summary state for the bundle's resources. | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts | ResourceCounts contains the number of resources in each state over all bundles in the cluster group. | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -771,7 +771,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationList
 
@@ -782,7 +782,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistration](#clusterregistration) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -794,7 +794,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clientRandom | ClientRandom is a random string that the agent generates. When fleet-controller grants a registration, it creates a registration secret with this string in the name. | string | false |
 | clusterLabels | ClusterLabels are copied to the cluster resource during the registration. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -805,7 +805,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clusterName | ClusterName is only set after the registration is being processed by fleet-controller. | string | false |
 | granted | Granted is set to true, if the request service account is present and its token secret exists. This happens directly before creating the registration secret, roles and rolebindings. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -817,7 +817,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenList
 
@@ -828,7 +828,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistrationToken](#clusterregistrationtoken) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -838,7 +838,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | ----- | ----------- | ------ | -------- |
 | ttl | TTL is the time to live for the token. It is used to calculate the expiration time. If the token expires, it will be deleted. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -849,7 +849,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | expires | Expires is the time when the token expires. | *metav1.Time | false |
 | secretName | SecretName is the name of the secret containing the token. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -861,7 +861,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | content | Content is a byte array, which contains the manifests of a bundle. The bundle resources are copied into the bundledeployment's content resource, so the downstream agent can deploy them. | []byte | false |
 | sha256sum | SHA256Sum of the Content field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ContentList
 
@@ -872,7 +872,7 @@ ContentList contains a list of Content
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Content](#content) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -884,7 +884,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CorrectDrift
 
@@ -896,7 +896,7 @@ CommitSpec specifies how to commit changes to the git repository
 | force | Force helm rollback with --force option will be used if true. This will try to recreate all resources in the release. | bool | false |
 | keepFailHistory | KeepFailHistory keeps track of failed rollbacks in the helm history. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepo
 
@@ -908,7 +908,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -921,7 +921,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | message | Message contains the relevant message from the deployment conditions. | string | false |
 | error | Error is true if a message is present. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoList
 
@@ -932,7 +932,7 @@ GitRepoList contains a list of GitRepo
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepo](#gitrepo) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -953,7 +953,7 @@ GitRepoResource contains metadata about the resources of a bundle.
 | message | Message is the first message from the PerClusterStates. | string | false |
 | perClusterState | PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources. | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -970,7 +970,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | unknown | Unknown is the number of resources in an unknown state. | int | true |
 | notReady | NotReady is the number of not ready resources. Resources are not ready if they do not match any other state. | int | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -1002,7 +1002,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | disablePolling | Disables git polling. When enabled only webhooks will be used. | bool | false |
 | ociRegistry | OCIRegistry specifies the OCI registry related parameters | *[OCIRegistrySpec](#ociregistryspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -1026,7 +1026,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | lastSyncedImageScanTime | LastSyncedImageScanTime is the time of the last image scan. | metav1.Time | false |
 | lastPollingTriggered | LastPollingTime is the last time the polling check was triggered | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -1040,7 +1040,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | clusterGroup | ClusterGroup is the name of a cluster group in the same namespace as the clusters. | string | false |
 | clusterGroupSelector | ClusterGroupSelector is a label selector to select cluster groups. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### OCIRegistrySpec
 
@@ -1053,7 +1053,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | basicHTTP | BasicHTTP uses HTTP connections to the OCI registry when enabled. | bool | false |
 | insecureSkipTLS | InsecureSkipTLS allows connections to OCI registry without certs when enabled. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -1068,7 +1068,7 @@ ResourcePerClusterState is generated for each non-ready resource of the bundles.
 | patch | Patch for modified resources. | *GenericMap | false |
 | clusterId | ClusterID is the id of the cluster. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -1084,7 +1084,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | allowedClientSecretNames | AllowedClientSecretNames is a list of client secret names that GitRepos are allowed to use. | []string | false |
 | allowedTargetNamespaces | AllowedTargetNamespaces restricts TargetNamespace to the given namespaces. If AllowedTargetNamespaces is set, TargetNamespace must be set. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestrictionList
 
@@ -1095,7 +1095,7 @@ GitRepoRestrictionList contains a list of GitRepoRestriction
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepoRestriction](#gitreporestriction) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -1105,7 +1105,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -1116,7 +1116,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -1128,7 +1128,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanList
 
@@ -1139,7 +1139,7 @@ ImageScanList contains a list of ImageScan
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ImageScan](#imagescan) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -1155,7 +1155,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -1171,7 +1171,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -1181,7 +1181,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### FleetYAML
 
@@ -1196,7 +1196,7 @@ FleetYAML is the top-level structure of the fleet.yaml file. The fleet.yaml file
 | imageScans | ImageScans are optional and used to update container image references in the git repo. | \[\][ImageScanYAML](#imagescanyaml) | false |
 | overrideTargets | OverrideTargets overrides targets that are defined in the GitRepo resource. If overrideTargets is provided the bundle will not inherit targets from the GitRepo. | \[\][GitTarget](#gittarget) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanYAML
 
@@ -1207,4 +1207,4 @@ ImageScanYAML is a single entry in the ImageScan list from fleet.yaml.
 | name | Name of the image scan. Unused. | string | false |
 | ImageScanSpec |  | [ImageScanSpec](#imagescanspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)

--- a/versioned_docs/version-0.13/cli/fleet-controller/fleet-controller.md
+++ b/versioned_docs/version-0.13/cli/fleet-controller/fleet-controller.md
@@ -29,6 +29,6 @@ fleet-controller [flags]
 
 ### SEE ALSO
 
-* [fleet-controller agentmanagement](fleet-controller_agentmanagement)	 -
-* [fleet-controller cleanup](fleet-controller_cleanup)	 -
-* [fleet-controller gitjob](fleet-controller_gitjob)	 -
+* [fleet-controller agentmanagement](fleet-controller_agentmanagement.md)	 -
+* [fleet-controller cleanup](fleet-controller_cleanup.md)	 -
+* [fleet-controller gitjob](fleet-controller_gitjob.md)	 -

--- a/versioned_docs/version-0.13/oci-storage.md
+++ b/versioned_docs/version-0.13/oci-storage.md
@@ -11,7 +11,7 @@ Using an OCI registry helps you:
 * Reduce etcd load by offloading large bundle content.  
 * Use a standardized storage backend for large manifests or Helm charts.
 
-![A visual asset displaying the flow of Fleet with OCI Storage.](../static/img/fleet-ociStorage-flow.png)
+![A visual asset displaying the flow of Fleet with OCI Storage.](../../static/img/fleet-ociStorage-flow.png)
 
 :::note
 Fleet checks for the integrity of OCI artifacts and Fleet tags OCI artifact as `latest`.
@@ -117,4 +117,4 @@ To decrypt your secret, you can run:
 
 `kubectl get secret ocistorage -n fleet-local -o json | jq '.data | map_values(@base64d)`
 
-![A screenshot of OCI secrets enabled for Fleet](../static/img/ociStorage-secret-ss.png)
+![A screenshot of OCI secrets enabled for Fleet](../../static/img/ociStorage-secret-ss.png)

--- a/versioned_docs/version-0.13/ref-crds.md
+++ b/versioned_docs/version-0.13/ref-crds.md
@@ -97,7 +97,7 @@ When a GitRepo is scanned it will produce one or more bundles. Bundles are a col
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -108,7 +108,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | readyClusters | ReadyClusters is a string in the form \"%d/%d\", that describes the number of clusters that are ready vs. the number of clusters desired to be ready. | string | false |
 | state | State is a summary state for the bundle, calculated over the non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleList
 
@@ -119,7 +119,7 @@ BundleList contains a list of Bundle
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Bundle](#bundle) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -130,7 +130,7 @@ BundleList contains a list of Bundle
 | name | Name of the bundle. | string | false |
 | selector | Selector matching bundle's labels. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -142,7 +142,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | content | The content of the resource, can be compressed. | string | false |
 | encoding | Encoding is either empty or \"base64+gz\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -158,7 +158,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 | contentsId | ContentsID stores the contents id when deploying contents using an OCI registry. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -181,7 +181,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | observedGeneration | ObservedGeneration is the current generation of the bundle. | int64 | true |
 | resourcesSha256Sum | ResourcesSHA256Sum corresponds to the JSON serialization of the .Spec.Resources field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -199,7 +199,7 @@ BundleSummary contains the number of bundle deployments in each state and a list
 | desiredReady | DesiredReady is the number of bundle deployments that should be ready. | int | true |
 | nonReadyResources | NonReadyClusters is a list of states, which is filled for a bundle that is not ready. | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -216,7 +216,7 @@ BundleTarget declares clusters to deploy to. Fleet will merge the BundleDeployme
 | namespaceLabels | NamespaceLabels are labels that will be appended to the namespace created by Fleet. | map[string]string | false |
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -230,7 +230,7 @@ BundleTargetRestriction is used internally by Fleet and should not be modified. 
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -244,7 +244,7 @@ NonReadyResource contains information about a bundle that is not ready for a giv
 | modifiedStatus | ModifiedStatus lists the state for each modified resource. | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus | NonReadyStatus lists the state for each non-ready resource. | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -259,7 +259,7 @@ Partition defines a separate rollout strategy for a set of clusters.
 | clusterGroup | A cluster group name to include in this partition | string | false |
 | clusterGroupSelector | Selector matching cluster group labels to include in this partition | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -273,7 +273,7 @@ PartitionStatus is the status of a single rollout partition.
 | unavailable | Unavailable is the number of unavailable clusters in the partition. | int | false |
 | summary | Summary is a summary state for the partition, calculated over its non-ready resources. | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -286,7 +286,7 @@ ResourceKey lists resources, which will likely be deployed.
 | namespace | Namespace is the namespace of the resource. | string | false |
 | name | Name is the name of the resource. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -299,7 +299,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | autoPartitionSize | A number or percentage of how to automatically partition clusters if no specific partitioning strategy is configured. default: 25% | *intstr.IntOrString | false |
 | partitions | A list of definitions of partitions.  If any target clusters do not match the configuration they are added to partitions at the end following the autoPartitionSize. | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -311,7 +311,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -323,7 +323,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentList
 
@@ -334,7 +334,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleDeployment](#bundledeployment) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -358,7 +358,7 @@ BundleDeploymentList contains a list of BundleDeployment
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | map[string]string | false |
 | deleteCRDResources | DeleteCRDResources deletes CRDs. Warning! this will also delete all your Custom Resources. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentResource
 
@@ -372,7 +372,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | name |  | string | false |
 | createdAt |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -389,7 +389,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | correctDrift | CorrectDrift specifies how drift correction should work. | *[CorrectDrift](#correctdrift) | false |
 | ociContents | OCIContents is true when this deployment's contents is stored in an oci registry | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -408,7 +408,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | syncGeneration |  | *int64 | false |
 | resources | Resources lists the metadata of resources that were deployed according to the helm release history. | \[\][BundleDeploymentResource](#bundledeploymentresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -423,7 +423,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | operations | Operations remove a JSON path from the resource. | \[\][Operation](#operation) | false |
 | jsonPointers | JSONPointers ignore diffs at a certain JSON path. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -434,7 +434,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -444,7 +444,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | ----- | ----------- | ------ | -------- |
 | comparePatches | ComparePatches match a resource and remove fields from the check for modifications. | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -470,7 +470,7 @@ HelmOptions for the deployment. For Helm-based bundles, all options can be used,
 | skipSchemaValidation | SkipSchemaValidation allows skipping schema validation against the chart values | bool | false |
 | disableDependencyUpdate | DisableDependencyUpdate allows skipping chart dependencies update | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -480,7 +480,7 @@ IgnoreOptions defines conditions to be ignored when monitoring the Bundle.
 | ----- | ----------- | ------ | -------- |
 | conditions | Conditions is a list of conditions to be ignored when monitoring the Bundle. | []map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -490,7 +490,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | dir | Dir points to a custom folder for kustomize resources. This folder must contain a kustomization.yaml file. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -500,7 +500,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | name | Name of a resource in the same namespace as the referent. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -517,7 +517,7 @@ ModifiedStatus is used to report the status of a resource that is modified. It i
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -532,7 +532,7 @@ NonReadyStatus is used to report the status of a resource that is not ready. It 
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -544,7 +544,7 @@ Operation of a ComparePatch, usually \"remove\".
 | path | Path is the JSON path to remove. | string | false |
 | value | Value is usually empty. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -555,7 +555,7 @@ Operation of a ComparePatch, usually \"remove\".
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -566,7 +566,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -576,7 +576,7 @@ YAMLOptions, if using raw YAML these are names that map to overlays/`{name}` fil
 | ----- | ----------- | ------ | -------- |
 | overlays | Overlays is a list of names that maps to folders in \"overlays/\". If you wish to customize the file ./subdir/resource.yaml then a file ./overlays/myoverlay/subdir/resource.yaml will replace the base file. A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -588,7 +588,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMappingList
 
@@ -599,7 +599,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][BundleNamespaceMapping](#bundlenamespacemapping) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -610,7 +610,7 @@ BundleNamespaceMappingList contains a list of BundleNamespaceMapping
 | lastSeen | LastSeen is the last time the agent checked in to update the status of the cluster resource. | metav1.Time | true |
 | namespace | Namespace is the namespace of the agent deployment, e.g. \"cattle-fleet-system\". | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -622,7 +622,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -633,7 +633,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State of the cluster, either one of the bundle states, or \"WaitCheckIn\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterList
 
@@ -644,7 +644,7 @@ ClusterList contains a list of Cluster
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Cluster](#cluster) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -666,7 +666,7 @@ ClusterList contains a list of Cluster
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *corev1.ResourceRequirements | false |
 | hostNetwork | HostNetwork sets the agent StatefulSet to use hostNetwork: true setting. Allows for provisioning of network related bundles (CNI configuration). | *bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -698,7 +698,7 @@ ClusterList contains a list of Cluster
 | agent | AgentStatus contains information about the agent. | [AgentStatus](#agentstatus) | false |
 | garbageCollectionInterval | GarbageCollectionInterval determines how often agents clean up obsolete Helm releases. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -710,7 +710,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -722,7 +722,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State is a summary state for the cluster group, showing \"NotReady\" if there are non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupList
 
@@ -733,7 +733,7 @@ ClusterGroupList contains a list of ClusterGroup
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterGroup](#clustergroup) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -743,7 +743,7 @@ ClusterGroupList contains a list of ClusterGroup
 | ----- | ----------- | ------ | -------- |
 | selector | Selector is a label selector, used to select clusters for this group. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -759,7 +759,7 @@ ClusterGroupList contains a list of ClusterGroup
 | display | Display contains the number of ready, desiredready clusters and a summary state for the bundle's resources. | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts | ResourceCounts contains the number of resources in each state over all bundles in the cluster group. | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -771,7 +771,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationList
 
@@ -782,7 +782,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistration](#clusterregistration) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -794,7 +794,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clientRandom | ClientRandom is a random string that the agent generates. When fleet-controller grants a registration, it creates a registration secret with this string in the name. | string | false |
 | clusterLabels | ClusterLabels are copied to the cluster resource during the registration. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -805,7 +805,7 @@ ClusterRegistrationList contains a list of ClusterRegistration
 | clusterName | ClusterName is only set after the registration is being processed by fleet-controller. | string | false |
 | granted | Granted is set to true, if the request service account is present and its token secret exists. This happens directly before creating the registration secret, roles and rolebindings. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -817,7 +817,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenList
 
@@ -828,7 +828,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ClusterRegistrationToken](#clusterregistrationtoken) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -838,7 +838,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | ----- | ----------- | ------ | -------- |
 | ttl | TTL is the time to live for the token. It is used to calculate the expiration time. If the token expires, it will be deleted. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -849,7 +849,7 @@ ClusterRegistrationTokenList contains a list of ClusterRegistrationToken
 | expires | Expires is the time when the token expires. | *metav1.Time | false |
 | secretName | SecretName is the name of the secret containing the token. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -861,7 +861,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | content | Content is a byte array, which contains the manifests of a bundle. The bundle resources are copied into the bundledeployment's content resource, so the downstream agent can deploy them. | []byte | false |
 | sha256sum | SHA256Sum of the Content field | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ContentList
 
@@ -872,7 +872,7 @@ ContentList contains a list of Content
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][Content](#content) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -884,7 +884,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CorrectDrift
 
@@ -896,7 +896,7 @@ CommitSpec specifies how to commit changes to the git repository
 | force | Force helm rollback with --force option will be used if true. This will try to recreate all resources in the release. | bool | false |
 | keepFailHistory | KeepFailHistory keeps track of failed rollbacks in the helm history. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepo
 
@@ -908,7 +908,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -921,7 +921,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | message | Message contains the relevant message from the deployment conditions. | string | false |
 | error | Error is true if a message is present. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoList
 
@@ -932,7 +932,7 @@ GitRepoList contains a list of GitRepo
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepo](#gitrepo) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -953,7 +953,7 @@ GitRepoResource contains metadata about the resources of a bundle.
 | message | Message is the first message from the PerClusterStates. | string | false |
 | perClusterState | PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources. | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -970,7 +970,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | unknown | Unknown is the number of resources in an unknown state. | int | true |
 | notReady | NotReady is the number of not ready resources. Resources are not ready if they do not match any other state. | int | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -1002,7 +1002,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | disablePolling | Disables git polling. When enabled only webhooks will be used. | bool | false |
 | ociRegistry | OCIRegistry specifies the OCI registry related parameters | *[OCIRegistrySpec](#ociregistryspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -1026,7 +1026,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | lastSyncedImageScanTime | LastSyncedImageScanTime is the time of the last image scan. | metav1.Time | false |
 | lastPollingTriggered | LastPollingTime is the last time the polling check was triggered | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -1040,7 +1040,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | clusterGroup | ClusterGroup is the name of a cluster group in the same namespace as the clusters. | string | false |
 | clusterGroupSelector | ClusterGroupSelector is a label selector to select cluster groups. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### OCIRegistrySpec
 
@@ -1053,7 +1053,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | basicHTTP | BasicHTTP uses HTTP connections to the OCI registry when enabled. | bool | false |
 | insecureSkipTLS | InsecureSkipTLS allows connections to OCI registry without certs when enabled. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -1068,7 +1068,7 @@ ResourcePerClusterState is generated for each non-ready resource of the bundles.
 | patch | Patch for modified resources. | *GenericMap | false |
 | clusterId | ClusterID is the id of the cluster. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -1084,7 +1084,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | allowedClientSecretNames | AllowedClientSecretNames is a list of client secret names that GitRepos are allowed to use. | []string | false |
 | allowedTargetNamespaces | AllowedTargetNamespaces restricts TargetNamespace to the given namespaces. If AllowedTargetNamespaces is set, TargetNamespace must be set. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestrictionList
 
@@ -1095,7 +1095,7 @@ GitRepoRestrictionList contains a list of GitRepoRestriction
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][GitRepoRestriction](#gitreporestriction) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -1105,7 +1105,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -1116,7 +1116,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -1128,7 +1128,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanList
 
@@ -1139,7 +1139,7 @@ ImageScanList contains a list of ImageScan
 | metadata |  | metav1.ListMeta | false |
 | items |  | \[\][ImageScan](#imagescan) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -1155,7 +1155,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -1171,7 +1171,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -1181,7 +1181,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### FleetYAML
 
@@ -1196,7 +1196,7 @@ FleetYAML is the top-level structure of the fleet.yaml file. The fleet.yaml file
 | imageScans | ImageScans are optional and used to update container image references in the git repo. | \[\][ImageScanYAML](#imagescanyaml) | false |
 | overrideTargets | OverrideTargets overrides targets that are defined in the GitRepo resource. If overrideTargets is provided the bundle will not inherit targets from the GitRepo. | \[\][GitTarget](#gittarget) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanYAML
 
@@ -1207,4 +1207,4 @@ ImageScanYAML is a single entry in the ImageScan list from fleet.yaml.
 | name | Name of the image scan. Unused. | string | false |
 | ImageScanSpec |  | [ImageScanSpec](#imagescanspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)

--- a/versioned_docs/version-0.13/rollout.md
+++ b/versioned_docs/version-0.13/rollout.md
@@ -43,7 +43,7 @@ Fleet rolls out deployments in batches of up to 50 clusters per partition, regar
 
 The following diagram displays how Fleet handles rollout:
 
-![A visual asset displaying flow of rollout in Fleet.](../static/img/flow-rollout-fleet.png)
+![A visual asset displaying flow of rollout in Fleet.](../../static/img/flow-rollout-fleet.png)
 
 Various limits that can be configured in Fleet:
 
@@ -93,7 +93,7 @@ Fleet then:
 
 The following diagram illustrates how Fleet handles rollout across multiple partitions, including readiness checks and deployment flow:
 
-![A visual asset displaying the flow of partition rollout](../static/img/deploy-targets-partition.png)
+![A visual asset displaying the flow of partition rollout](../../static/img/deploy-targets-partition.png)
 
 :::note
 MaxNew is always 50. A bundle change can only stage 50 `BundleDeployments` at a time.	
@@ -101,7 +101,7 @@ MaxNew is always 50. A bundle change can only stage 50 `BundleDeployments` at a 
 
 Within each partition, Fleet rolls out up to 50 `BundleDeployments` at a time. The diagram below shows how Fleet determines whether to proceed or wait during this process:
 
-![A visual asset displaying the flow of deploying targets in a partition](../static/img/partition-rollout-flow.png)
+![A visual asset displaying the flow of deploying targets in a partition](../../static/img/partition-rollout-flow.png)
 
 :::note
 Fleet recommends labeling clusters so you can use those labels to assign clusters to specific partitions.
@@ -177,7 +177,7 @@ rolloutStrategy:
 
 The following diagram illustrates how Fleet handles 50 clusters in a single partition:
 
-![A visual asset displaying 50 clusters](../static/img/deploy-50Clusters.png)
+![A visual asset displaying 50 clusters](../../static/img/deploy-50Clusters.png)
 
 ### Scenario: 100 Clusters (Single Partition) 
 
@@ -233,7 +233,7 @@ rolloutStrategy:
 
 The following diagram describes how Fleet handles whether to continue or pause rollout.
 
-![A visual asset displaying the partitions about rollout in Fleet](../static/img/partition-fleet-rollout.png)
+![A visual asset displaying the partitions about rollout in Fleet](../../static/img/partition-fleet-rollout.png)
 
 This ensures full readiness and staged rollout across all 200 clusters. Use this approach when you need precise rollout sequencing and full cluster readiness before advancing. 
 

--- a/versioned_docs/version-0.6/ref-crds.md
+++ b/versioned_docs/version-0.6/ref-crds.md
@@ -78,7 +78,7 @@
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -91,7 +91,7 @@
 | message |  | string | false |
 | error |  | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -112,7 +112,7 @@
 | message |  | string | false |
 | perClusterState |  | [][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -129,7 +129,7 @@
 | unknown |  | int | true |
 | notReady |  | int | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -145,7 +145,7 @@
 | allowedClientSecretNames |  | []string | false |
 | allowedTargetNamespaces |  | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -172,7 +172,7 @@
 | imageScanCommit | Commit specifies how to commit to the git repo when new image is scanned and write back to git repo | [CommitSpec](#commitspec) | false |
 | keepResources | KeepResources specifies if the resources created must be kept after deleting the GitRepo | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -193,7 +193,7 @@
 | resourceErrors |  | []string | false |
 | lastSyncedImageScanTime |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -207,7 +207,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -222,7 +222,7 @@
 | patch |  | *GenericMap | false |
 | clusterId |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Bundle
 
@@ -234,7 +234,7 @@
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -246,7 +246,7 @@
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -258,7 +258,7 @@
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -276,7 +276,7 @@
 | diff | Diff can be used to ignore the modified state of objects which are amended at runtime. | *[DiffOptions](#diffoptions) | false |
 | keepResources | KeepResources can be used to keep the deployed resources when removing the bundle | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -290,7 +290,7 @@
 | deploymentID |  | string | false |
 | dependsOn |  | [][BundleRef](#bundleref) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -308,7 +308,7 @@
 | display |  | [BundleDeploymentDisplay](#bundledeploymentdisplay) | false |
 | syncGeneration |  | *int64 | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -319,7 +319,7 @@
 | readyClusters |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -331,7 +331,7 @@
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -342,7 +342,7 @@
 | name |  | string | false |
 | selector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -354,7 +354,7 @@
 | content |  | string | false |
 | encoding |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -370,7 +370,7 @@
 | targetRestrictions | TargetRestrictions restrict which clusters the bundle will be deployed to. | [][BundleTargetRestriction](#bundletargetrestriction) | false |
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | [][BundleRef](#bundleref) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -391,7 +391,7 @@
 | resourceKey |  | [][ResourceKey](#resourcekey) | false |
 | observedGeneration |  | int64 | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -409,7 +409,7 @@
 | desiredReady |  | int | true |
 | nonReadyResources |  | [][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -424,7 +424,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -438,7 +438,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -453,7 +453,7 @@
 | operations |  | [][Operation](#operation) | false |
 | jsonPointers |  | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -464,7 +464,7 @@
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -475,7 +475,7 @@
 | metadata |  | metav1.ObjectMeta | false |
 | content |  | []byte | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -485,7 +485,7 @@
 | ----- | ----------- | ------ | -------- |
 | comparePatches |  | [][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -508,7 +508,7 @@
 | atomic | Atomic sets the --atomic flag when Helm is performing an upgrade | bool | false |
 | disablePreProcess | DisablePreProcess disables template processing in values | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -518,7 +518,7 @@
 | ----- | ----------- | ------ | -------- |
 | dir |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -528,7 +528,7 @@
 | ----- | ----------- | ------ | -------- |
 | name |  | string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -544,7 +544,7 @@
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -558,7 +558,7 @@
 | modifiedStatus |  | [][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus |  | [][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -573,7 +573,7 @@
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -585,7 +585,7 @@
 | path |  | string | false |
 | value |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -600,7 +600,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -614,7 +614,7 @@
 | unavailable |  | int | false |
 | summary |  | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -627,7 +627,7 @@
 | namespace |  | string | false |
 | name |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -640,7 +640,7 @@
 | autoPartitionSize |  | *intstr.IntOrString | false |
 | partitions |  | [][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -651,7 +651,7 @@
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -662,7 +662,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -672,7 +672,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | ----- | ----------- | ------ | -------- |
 | overlays |  | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -682,7 +682,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -694,7 +694,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -705,7 +705,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -717,7 +717,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -733,7 +733,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -749,7 +749,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -759,7 +759,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -774,7 +774,7 @@ SemVerPolicy specifies a semantic version policy.
 | nonReadyNodeNames | At most 3 nodes | []string | true |
 | readyNodeNames | At most 3 nodes | []string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -786,7 +786,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -799,7 +799,7 @@ SemVerPolicy specifies a semantic version policy.
 | sampleNode |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -811,7 +811,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -823,7 +823,7 @@ SemVerPolicy specifies a semantic version policy.
 | readyBundles |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -833,7 +833,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | selector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -849,7 +849,7 @@ SemVerPolicy specifies a semantic version policy.
 | display |  | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts |  | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -861,7 +861,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -873,7 +873,7 @@ SemVerPolicy specifies a semantic version policy.
 | clientRandom |  | string | false |
 | clusterLabels |  | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -884,7 +884,7 @@ SemVerPolicy specifies a semantic version policy.
 | clusterName |  | string | false |
 | granted |  | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -896,7 +896,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -906,7 +906,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | ttl |  | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -917,7 +917,7 @@ SemVerPolicy specifies a semantic version policy.
 | expires |  | *metav1.Time | false |
 | secretName |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -935,7 +935,7 @@ SemVerPolicy specifies a semantic version policy.
 | templateValues | TemplateValues defines a cluster specific mapping of values to be sent to fleet.yaml values templating. | *GenericMap | false |
 | agentTolerations | AgentTolerations defines an extra set of Tolerations to be added to the Agent deployment. | []v1.Toleration | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -958,4 +958,4 @@ SemVerPolicy specifies a semantic version policy.
 | display |  | [ClusterDisplay](#clusterdisplay) | false |
 | agent |  | [AgentStatus](#agentstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)

--- a/versioned_docs/version-0.7/ref-crds.md
+++ b/versioned_docs/version-0.7/ref-crds.md
@@ -79,7 +79,7 @@
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -92,7 +92,7 @@
 | message |  | string | false |
 | error |  | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -113,7 +113,7 @@
 | message |  | string | false |
 | perClusterState |  | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -130,7 +130,7 @@
 | unknown |  | int | true |
 | notReady |  | int | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -146,7 +146,7 @@
 | allowedClientSecretNames |  | []string | false |
 | allowedTargetNamespaces |  | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -173,7 +173,7 @@
 | imageScanCommit | Commit specifies how to commit to the git repo when new image is scanned and write back to git repo | [CommitSpec](#commitspec) | false |
 | keepResources | KeepResources specifies if the resources created must be kept after deleting the GitRepo | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -194,7 +194,7 @@
 | resourceErrors |  | []string | false |
 | lastSyncedImageScanTime |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -208,7 +208,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -223,7 +223,7 @@
 | patch |  | *GenericMap | false |
 | clusterId |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Bundle
 
@@ -235,7 +235,7 @@
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -247,7 +247,7 @@
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -259,7 +259,7 @@
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -277,7 +277,7 @@
 | diff | Diff can be used to ignore the modified state of objects which are amended at runtime. | *[DiffOptions](#diffoptions) | false |
 | keepResources | KeepResources can be used to keep the deployed resources when removing the bundle | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -291,7 +291,7 @@
 | deploymentID |  | string | false |
 | dependsOn |  | \[\][BundleRef](#bundleref) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -309,7 +309,7 @@
 | display |  | [BundleDeploymentDisplay](#bundledeploymentdisplay) | false |
 | syncGeneration |  | *int64 | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -320,7 +320,7 @@
 | readyClusters |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -332,7 +332,7 @@
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -343,7 +343,7 @@
 | name |  | string | false |
 | selector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -355,7 +355,7 @@
 | content |  | string | false |
 | encoding |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -372,7 +372,7 @@
 | dependsOn               | DependsOn refers to the bundles which must be ready before this bundle can be deployed.                                     | \[\][BundleRef](#bundleref)                           | false |
 | ignore                  | Ignore refers to the fields that will not be considered when monitoring the status.                                         | [IgnoreOptions](#ignoreoptions)                     | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -393,7 +393,7 @@
 | resourceKey |  | \[\][ResourceKey](#resourcekey) | false |
 | observedGeneration |  | int64 | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -411,7 +411,7 @@
 | desiredReady |  | int | true |
 | nonReadyResources |  | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -426,7 +426,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -440,7 +440,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -455,7 +455,7 @@
 | operations |  | \[\][Operation](#operation) | false |
 | jsonPointers |  | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -466,7 +466,7 @@
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -477,7 +477,7 @@
 | metadata |  | metav1.ObjectMeta | false |
 | content |  | []byte | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -487,7 +487,7 @@
 | ----- | ----------- | ------ | -------- |
 | comparePatches |  | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -510,7 +510,7 @@
 | atomic | Atomic sets the --atomic flag when Helm is performing an upgrade | bool | false |
 | disablePreProcess | DisablePreProcess disables template processing in values | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -520,7 +520,7 @@
 | ----- | ----------- | ------ | -------- |
 | dir |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -530,7 +530,7 @@
 | ----- | ----------- | ------ | -------- |
 | name |  | string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -546,7 +546,7 @@
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -560,7 +560,7 @@
 | modifiedStatus |  | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus |  | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -575,7 +575,7 @@
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -587,7 +587,7 @@
 | path |  | string | false |
 | value |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -602,7 +602,7 @@
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -616,7 +616,7 @@
 | unavailable |  | int | false |
 | summary |  | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -629,7 +629,7 @@
 | namespace |  | string | false |
 | name |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -642,7 +642,7 @@
 | autoPartitionSize |  | *intstr.IntOrString | false |
 | partitions |  | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -653,7 +653,7 @@
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -664,7 +664,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -674,7 +674,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | ----- | ----------- | ------ | -------- |
 | overlays |  | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -684,7 +684,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -696,7 +696,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -707,7 +707,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -719,7 +719,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -735,7 +735,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -751,7 +751,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -761,7 +761,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -776,7 +776,7 @@ SemVerPolicy specifies a semantic version policy.
 | nonReadyNodeNames | At most 3 nodes | []string | true |
 | readyNodeNames | At most 3 nodes | []string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -794,7 +794,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -807,7 +807,7 @@ SemVerPolicy specifies a semantic version policy.
 | sampleNode |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -819,7 +819,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -831,7 +831,7 @@ SemVerPolicy specifies a semantic version policy.
 | readyBundles |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -841,7 +841,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | selector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -857,7 +857,7 @@ SemVerPolicy specifies a semantic version policy.
 | display |  | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts |  | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -869,7 +869,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -881,7 +881,7 @@ SemVerPolicy specifies a semantic version policy.
 | clientRandom |  | string | false |
 | clusterLabels |  | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -892,7 +892,7 @@ SemVerPolicy specifies a semantic version policy.
 | clusterName |  | string | false |
 | granted |  | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -904,7 +904,7 @@ SemVerPolicy specifies a semantic version policy.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -914,7 +914,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | ttl |  | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -925,7 +925,7 @@ SemVerPolicy specifies a semantic version policy.
 | expires |  | *metav1.Time | false |
 | secretName |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -945,7 +945,7 @@ SemVerPolicy specifies a semantic version policy.
 | agentAffinity | AgentAffinity overrides the default affinity for the cluster's agent deployment. If this value is nil the default affinity is used. | *v1.Affinity | false |
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *v1.ResourceRequirements | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -971,4 +971,4 @@ SemVerPolicy specifies a semantic version policy.
 | display |  | [ClusterDisplay](#clusterdisplay) | false |
 | agent |  | [AgentStatus](#agentstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)

--- a/versioned_docs/version-0.8/ref-crds.md
+++ b/versioned_docs/version-0.8/ref-crds.md
@@ -81,7 +81,7 @@
 | force | Force helm rollback with --force option will be used if true. This will try to recreate all resources in the release. | bool | false |
 | keepFailHistory | KeepFailHistory keeps track of failed rollbacks in the helm history. | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepo
 
@@ -93,7 +93,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -106,7 +106,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | message | Message contains the relevant message from the deployment conditions. | string | false |
 | error | Error is true if a message is present. | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -127,7 +127,7 @@ GitRepoResource contains metadata about the resources of a bundle.
 | message | Message is the first message from the PerClusterStates. | string | false |
 | perClusterState | PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources. | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -144,7 +144,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | unknown | Unknown is the number of resources in an unknown state. | int | true |
 | notReady | NotReady is the number of not ready resources. Resources are not ready if they do not match any other state. | int | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -160,7 +160,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | allowedClientSecretNames | AllowedClientSecretNames is a list of client secret names that GitRepos are allowed to use. | []string | false |
 | allowedTargetNamespaces | AllowedTargetNamespaces restricts TargetNamespace to the given namespaces. If AllowedTargetNamespaces is set, TargetNamespace must be set. | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -189,7 +189,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | keepResources | KeepResources specifies if the resources created must be kept after deleting the GitRepo. | bool | false |
 | correctDrift | CorrectDrift specifies how drift correction should work. | [CorrectDrift](#correctdrift) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -210,7 +210,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | resourceErrors | ResourceErrors is a sorted list of errors from the resources. | []string | false |
 | lastSyncedImageScanTime | LastSyncedImageScanTime is the time of the last image scan. | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -224,7 +224,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | clusterGroup | ClusterGroup is the name of a cluster group in the same namespace as the clusters. | string | false |
 | clusterGroupSelector | ClusterGroupSelector is a label selector to select cluster groups. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -239,7 +239,7 @@ ResourcePerClusterState is generated for each non-ready resource of the bundles.
 | patch | Patch for modified resources. | *GenericMap | false |
 | clusterId | ClusterID is the id of the cluster. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Bundle
 
@@ -251,7 +251,7 @@ Bundle contains the resources of an application and its deployment options. It w
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -263,7 +263,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -275,7 +275,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -297,7 +297,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | namespaceLabels | NamespaceLabels are labels that will be appended to the namespace created by Fleet. | *map[string]string | false |
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | *map[string]string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentResource
 
@@ -311,7 +311,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | name |  | string | false |
 | createdAt |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -327,7 +327,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 | correctDrift | CorrectDrift specifies how drift correction should work. | [CorrectDrift](#correctdrift) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -346,7 +346,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | syncGeneration |  | *int64 | false |
 | resources | Resources lists the metadata of resources that were deployed according to the helm release history. | \[\][BundleDeploymentResource](#bundledeploymentresource) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -357,7 +357,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | readyClusters | ReadyClusters is a string in the form \"%d/%d\", that describes the number of clusters that are ready vs. the number of clusters desired to be ready. | string | false |
 | state | State is a summary state for the bundle, calculated over the non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -369,7 +369,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -380,7 +380,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | name | Name of the bundle. | string | false |
 | selector | Selector matching bundle's labels. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -392,7 +392,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | content | The content of the resource, can be compressed. | string | false |
 | encoding | Encoding is either empty or \"base64+gz\". | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -408,7 +408,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | targetRestrictions | TargetRestrictions is an allow list, which controls if a bundledeployment is created for a target. | \[\][BundleTargetRestriction](#bundletargetrestriction) | false |
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -429,7 +429,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | resourceKey | ResourceKey lists resources, which will likely be deployed. The actual list of resources on a cluster might differ, depending on the helm chart, value templating, etc.. | \[\][ResourceKey](#resourcekey) | false |
 | observedGeneration | ObservedGeneration is the current generation of the bundle. | int64 | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -447,7 +447,7 @@ BundleSummary contains the number of bundle deployments in each state and a list
 | desiredReady | DesiredReady is the number of bundle deployments that should be ready. | int | true |
 | nonReadyResources | NonReadyClusters is a list of states, which is filled for a bundle that is not ready. | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -463,7 +463,7 @@ BundleTarget declares clusters to deploy to. Fleet will merge the BundleDeployme
 | clusterGroupSelector | ClusterGroupSelector is a selector to match cluster groups. | *metav1.LabelSelector | false |
 | doNotDeploy | DoNotDeploy if set to true, will not deploy to this target. | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -477,7 +477,7 @@ BundleTargetRestriction is used internally by Fleet and should not be modified. 
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -492,7 +492,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | operations | Operations remove a JSON path from the resource. | \[\][Operation](#operation) | false |
 | jsonPointers | JSONPointers ignore diffs at a certain JSON path. | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -503,7 +503,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -514,7 +514,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | metadata |  | metav1.ObjectMeta | false |
 | content | Content is a byte array, which contains the manifests of a bundle. The bundle resources are copied into the bundledeployment's content resource, so the downstream agent can deploy them. | []byte | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -524,7 +524,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | ----- | ----------- | ------ | -------- |
 | comparePatches | ComparePatches match a resource and remove fields from the check for modifications. | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -547,7 +547,7 @@ HelmOptions for the deployment. For Helm-based bundles, all options can be used,
 | atomic | Atomic sets the --atomic flag when Helm is performing an upgrade | bool | false |
 | disablePreProcess | DisablePreProcess disables template processing in values | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -557,7 +557,7 @@ IgnoreOptions defines conditions to be ignored when monitoring the Bundle.
 | ----- | ----------- | ------ | -------- |
 | conditions | Conditions is a list of conditions to be ignored when monitoring the Bundle. | []map[string]string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -567,7 +567,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | dir | Dir points to a custom folder for kustomize resources. This folder must contain a kustomization.yaml file. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -577,7 +577,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | name | Name of a resource in the same namespace as the referent. | string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -593,7 +593,7 @@ ModifiedStatus is used to report the status of a resource that is modified. It i
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -607,7 +607,7 @@ NonReadyResource contains information about a bundle that is not ready for a giv
 | modifiedStatus | ModifiedStatus lists the state for each modified resource. | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus | NonReadyStatus lists the state for each non-ready resource. | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -622,7 +622,7 @@ NonReadyStatus is used to report the status of a resource that is not ready. It 
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -634,7 +634,7 @@ Operation of a ComparePatch, usually \"remove\".
 | path | Path is the JSON path to remove. | string | false |
 | value | Value is usually empty. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -649,7 +649,7 @@ Partition defines a separate rollout strategy for a set of clusters.
 | clusterGroup | A cluster group name to include in this partition | string | false |
 | clusterGroupSelector | Selector matching cluster group labels to include in this partition | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -663,7 +663,7 @@ PartitionStatus is the status of a single rollout partition.
 | unavailable | Unavailable is the number of unavailable clusters in the partition. | int | false |
 | summary | Summary is a summary state for the partition, calculated over its non-ready resources. | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -676,7 +676,7 @@ ResourceKey lists resources, which will likely be deployed.
 | namespace | Namespace is the namespace of the resource. | string | false |
 | name | Name is the name of the resource. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -689,7 +689,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | autoPartitionSize | A number or percentage of how to automatically partition clusters if no specific partitioning strategy is configured. default: 25% | *intstr.IntOrString | false |
 | partitions | A list of definitions of partitions.  If any target clusters do not match the configuration they are added to partitions at the end following the autoPartitionSize. | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -700,7 +700,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -711,7 +711,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -721,7 +721,7 @@ YAMLOptions, if using raw YAML these are names that map to overlays/`{name}` fil
 | ----- | ----------- | ------ | -------- |
 | overlays | Overlays is a list of names that maps to folders in \"overlays/\". If you wish to customize the file ./subdir/resource.yaml then a file ./overlays/myoverlay/subdir/resource.yaml will replace the base file. A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file. | []string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -731,7 +731,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -743,7 +743,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -754,7 +754,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -766,7 +766,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -782,7 +782,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -798,7 +798,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -808,7 +808,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -823,7 +823,7 @@ SemVerPolicy specifies a semantic version policy.
 | nonReadyNodeNames | NonReadyNode contains the names of non-ready nodes. The list is limited to at most 3 names. | []string | true |
 | readyNodeNames | ReadyNodes contains the names of ready nodes. The list is limited to at most 3 names. | []string | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -835,7 +835,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -848,7 +848,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | sampleNode | SampleNode is the name of one of the nodes that are ready. If no node is ready, it's the name of a node that is not ready. | string | false |
 | state | State of the cluster, either one of the bundle states, or \"WaitCheckIn\". | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -860,7 +860,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -872,7 +872,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State is a summary state for the cluster group, showing \"NotReady\" if there are non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -882,7 +882,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | ----- | ----------- | ------ | -------- |
 | selector | Selector is a label selector, used to select clusters for this group. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -898,7 +898,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | display | Display contains the number of ready, desiredready clusters and a summary state for the bundle's resources. | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts | ResourceCounts contains the number of resources in each state over all bundles in the cluster group. | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -910,7 +910,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -922,7 +922,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | clientRandom | ClientRandom is a random string that the agent generates. When fleet-controller grants a registration, it creates a registration secret with this string in the name. | string | false |
 | clusterLabels | ClusterLabels are copied to the cluster resource during the registration. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -933,7 +933,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | clusterName | ClusterName is only set after the registration is being processed by fleet-controller. | string | false |
 | granted | Granted is set to true, if the request service account is present and its token secret exists. This happens directly before creating the registration secret, roles and rolebindings. | bool | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -945,7 +945,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -955,7 +955,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | ----- | ----------- | ------ | -------- |
 | ttl | TTL is the time to live for the token. It is used to calculate the expiration time. If the token expires, it will be deleted. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -966,7 +966,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | expires | Expires is the time when the token expires. | *metav1.Time | false |
 | secretName | SecretName is the name of the secret containing the token. | string | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -986,7 +986,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | agentAffinity | AgentAffinity overrides the default affinity for the cluster's agent deployment. If this value is nil the default affinity is used. | *v1.Affinity | false |
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *v1.ResourceRequirements | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -1015,4 +1015,4 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | display | Display contains the number of ready bundles, nodes and a summary state. | [ClusterDisplay](#clusterdisplay) | false |
 | agent | AgentStatus contains information about the agent. | [AgentStatus](#agentstatus) | false |
 
-[Back to Custom Resources](#custom-resources)
+[Back to Custom Resources](#)

--- a/versioned_docs/version-0.9/ref-crds.md
+++ b/versioned_docs/version-0.9/ref-crds.md
@@ -85,7 +85,7 @@ When a GitRepo is scanned it will produce one or more bundles. Bundles are a col
 | spec |  | [BundleSpec](#bundlespec) | true |
 | status |  | [BundleStatus](#bundlestatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDisplay
 
@@ -96,7 +96,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | readyClusters | ReadyClusters is a string in the form \"%d/%d\", that describes the number of clusters that are ready vs. the number of clusters desired to be ready. | string | false |
 | state | State is a summary state for the bundle, calculated over the non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleRef
 
@@ -107,7 +107,7 @@ BundleDisplay contains the number of ready, desiredready clusters and a summary 
 | name | Name of the bundle. | string | false |
 | selector | Selector matching bundle's labels. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleResource
 
@@ -119,7 +119,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | content | The content of the resource, can be compressed. | string | false |
 | encoding | Encoding is either empty or \"base64+gz\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSpec
 
@@ -134,7 +134,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | targetRestrictions | TargetRestrictions is an allow list, which controls if a bundledeployment is created for a target. | \[\][BundleTargetRestriction](#bundletargetrestriction) | false |
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleStatus
 
@@ -155,7 +155,7 @@ BundleResource represents the content of a single resource from the bundle, like
 | resourceKey | ResourceKey lists resources, which will likely be deployed. The actual list of resources on a cluster might differ, depending on the helm chart, value templating, etc.. | \[\][ResourceKey](#resourcekey) | false |
 | observedGeneration | ObservedGeneration is the current generation of the bundle. | int64 | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleSummary
 
@@ -173,7 +173,7 @@ BundleSummary contains the number of bundle deployments in each state and a list
 | desiredReady | DesiredReady is the number of bundle deployments that should be ready. | int | true |
 | nonReadyResources | NonReadyClusters is a list of states, which is filled for a bundle that is not ready. | \[\][NonReadyResource](#nonreadyresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTarget
 
@@ -188,7 +188,7 @@ BundleTarget declares clusters to deploy to. Fleet will merge the BundleDeployme
 | clusterGroupSelector | ClusterGroupSelector is a selector to match cluster groups. | *metav1.LabelSelector | false |
 | doNotDeploy | DoNotDeploy if set to true, will not deploy to this target. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleTargetRestriction
 
@@ -202,7 +202,7 @@ BundleTargetRestriction is used internally by Fleet and should not be modified. 
 | clusterGroup |  | string | false |
 | clusterGroupSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyResource
 
@@ -216,7 +216,7 @@ NonReadyResource contains information about a bundle that is not ready for a giv
 | modifiedStatus | ModifiedStatus lists the state for each modified resource. | \[\][ModifiedStatus](#modifiedstatus) | false |
 | nonReadyStatus | NonReadyStatus lists the state for each non-ready resource. | \[\][NonReadyStatus](#nonreadystatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Partition
 
@@ -231,7 +231,7 @@ Partition defines a separate rollout strategy for a set of clusters.
 | clusterGroup | A cluster group name to include in this partition | string | false |
 | clusterGroupSelector | Selector matching cluster group labels to include in this partition | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### PartitionStatus
 
@@ -245,7 +245,7 @@ PartitionStatus is the status of a single rollout partition.
 | unavailable | Unavailable is the number of unavailable clusters in the partition. | int | false |
 | summary | Summary is a summary state for the partition, calculated over its non-ready resources. | [BundleSummary](#bundlesummary) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourceKey
 
@@ -258,7 +258,7 @@ ResourceKey lists resources, which will likely be deployed.
 | namespace | Namespace is the namespace of the resource. | string | false |
 | name | Name is the name of the resource. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### RolloutStrategy
 
@@ -271,7 +271,7 @@ RolloverStrategy controls the rollout of the bundle across clusters.
 | autoPartitionSize | A number or percentage of how to automatically partition clusters if no specific partitioning strategy is configured. default: 25% | *intstr.IntOrString | false |
 | partitions | A list of definitions of partitions.  If any target clusters do not match the configuration they are added to partitions at the end following the autoPartitionSize. | \[\][Partition](#partition) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeployment
 
@@ -283,7 +283,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | spec |  | [BundleDeploymentSpec](#bundledeploymentspec) | false |
 | status |  | [BundleDeploymentStatus](#bundledeploymentstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentDisplay
 
@@ -295,7 +295,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | monitored |  | string | false |
 | state |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentOptions
 
@@ -318,7 +318,7 @@ BundleDeployment is used internally by Fleet and should not be used directly. Wh
 | namespaceAnnotations | NamespaceAnnotations are annotations that will be appended to the namespace created by Fleet. | *map[string]string | false |
 | deleteCRDResources | DeleteCRDResources deletes CRDs. Warning! this will also delete all your Custom Resources. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentResource
 
@@ -332,7 +332,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | name |  | string | false |
 | createdAt |  | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentSpec
 
@@ -348,7 +348,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | dependsOn | DependsOn refers to the bundles which must be ready before this bundle can be deployed. | \[\][BundleRef](#bundleref) | false |
 | correctDrift | CorrectDrift specifies how drift correction should work. | *[CorrectDrift](#correctdrift) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleDeploymentStatus
 
@@ -367,7 +367,7 @@ BundleDeploymentResource contains the metadata of a deployed resource.
 | syncGeneration |  | *int64 | false |
 | resources | Resources lists the metadata of resources that were deployed according to the helm release history. | \[\][BundleDeploymentResource](#bundledeploymentresource) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ComparePatch
 
@@ -382,7 +382,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | operations | Operations remove a JSON path from the resource. | \[\][Operation](#operation) | false |
 | jsonPointers | JSONPointers ignore diffs at a certain JSON path. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ConfigMapKeySelector
 
@@ -393,7 +393,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### DiffOptions
 
@@ -403,7 +403,7 @@ ComparePatch matches a resource and removes fields from the check for modificati
 | ----- | ----------- | ------ | -------- |
 | comparePatches | ComparePatches match a resource and remove fields from the check for modifications. | \[\][ComparePatch](#comparepatch) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### HelmOptions
 
@@ -428,7 +428,7 @@ HelmOptions for the deployment. For Helm-based bundles, all options can be used,
 | disableDNS | DisableDNS can be used to customize Helm's EnableDNS option, which Fleet sets to `true` by default. | bool | false |
 | skipSchemaValidation | SkipSchemaValidation allows skipping schema validation against the chart values | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### IgnoreOptions
 
@@ -438,7 +438,7 @@ IgnoreOptions defines conditions to be ignored when monitoring the Bundle.
 | ----- | ----------- | ------ | -------- |
 | conditions | Conditions is a list of conditions to be ignored when monitoring the Bundle. | []map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### KustomizeOptions
 
@@ -448,7 +448,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | dir | Dir points to a custom folder for kustomize resources. This folder must contain a kustomization.yaml file. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### LocalObjectReference
 
@@ -458,7 +458,7 @@ KustomizeOptions for a deployment.
 | ----- | ----------- | ------ | -------- |
 | name | Name of a resource in the same namespace as the referent. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ModifiedStatus
 
@@ -474,7 +474,7 @@ ModifiedStatus is used to report the status of a resource that is modified. It i
 | delete |  | bool | false |
 | patch |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### NonReadyStatus
 
@@ -489,7 +489,7 @@ NonReadyStatus is used to report the status of a resource that is not ready. It 
 | name |  | string | false |
 | summary |  | summary.Summary | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Operation
 
@@ -501,7 +501,7 @@ Operation of a ComparePatch, usually \"remove\".
 | path | Path is the JSON path to remove. | string | false |
 | value | Value is usually empty. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SecretKeySelector
 
@@ -512,7 +512,7 @@ Operation of a ComparePatch, usually \"remove\".
 | namespace |  | string | false |
 | key |  | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ValuesFrom
 
@@ -523,7 +523,7 @@ Define helm values that can come from configmap, secret or external. Credit: htt
 | configMapKeyRef | The reference to a config map with release values. | *[ConfigMapKeySelector](#configmapkeyselector) | false |
 | secretKeyRef | The reference to a secret with release values. | *[SecretKeySelector](#secretkeyselector) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### YAMLOptions
 
@@ -533,7 +533,7 @@ YAMLOptions, if using raw YAML these are names that map to overlays/`{name}` fil
 | ----- | ----------- | ------ | -------- |
 | overlays | Overlays is a list of names that maps to folders in \"overlays/\". If you wish to customize the file ./subdir/resource.yaml then a file ./overlays/myoverlay/subdir/resource.yaml will replace the base file. A file named ./overlays/myoverlay/subdir/resource_patch.yaml will patch the base file. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### BundleNamespaceMapping
 
@@ -545,7 +545,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | bundleSelector |  | *metav1.LabelSelector | false |
 | namespaceSelector |  | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AgentStatus
 
@@ -560,7 +560,7 @@ BundleNamespaceMapping maps bundles to clusters in other namespaces.
 | nonReadyNodeNames | NonReadyNode contains the names of non-ready nodes. The list is limited to at most 3 names. | []string | true |
 | readyNodeNames | ReadyNodes contains the names of ready nodes. The list is limited to at most 3 names. | []string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Cluster
 
@@ -572,7 +572,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | spec |  | [ClusterSpec](#clusterspec) | false |
 | status |  | [ClusterStatus](#clusterstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterDisplay
 
@@ -585,7 +585,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | sampleNode | SampleNode is the name of one of the nodes that are ready. If no node is ready, it's the name of a node that is not ready. | string | false |
 | state | State of the cluster, either one of the bundle states, or \"WaitCheckIn\". | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterSpec
 
@@ -606,7 +606,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | agentAffinity | AgentAffinity overrides the default affinity for the cluster's agent deployment. If this value is nil the default affinity is used. | *corev1.Affinity | false |
 | agentResources | AgentResources sets the resources for the cluster's agent deployment. | *corev1.ResourceRequirements | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterStatus
 
@@ -636,7 +636,7 @@ Cluster corresponds to a Kubernetes cluster. Fleet deploys bundles to targeted c
 | display | Display contains the number of ready bundles, nodes and a summary state. | [ClusterDisplay](#clusterdisplay) | false |
 | agent | AgentStatus contains information about the agent. | [AgentStatus](#agentstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroup
 
@@ -648,7 +648,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | spec |  | [ClusterGroupSpec](#clustergroupspec) | true |
 | status |  | [ClusterGroupStatus](#clustergroupstatus) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupDisplay
 
@@ -660,7 +660,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | readyBundles | ReadyBundles is a string in the form \"%d/%d\", that describes the number of bundles that are ready vs. the number of bundles desired to be ready. | string | false |
 | state | State is a summary state for the cluster group, showing \"NotReady\" if there are non-ready resources. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupSpec
 
@@ -670,7 +670,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | ----- | ----------- | ------ | -------- |
 | selector | Selector is a label selector, used to select clusters for this group. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterGroupStatus
 
@@ -686,7 +686,7 @@ ClusterGroup is a re-usable selector to target a group of clusters.
 | display | Display contains the number of ready, desiredready clusters and a summary state for the bundle's resources. | [ClusterGroupDisplay](#clustergroupdisplay) | false |
 | resourceCounts | ResourceCounts contains the number of resources in each state over all bundles in the cluster group. | [GitRepoResourceCounts](#gitreporesourcecounts) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistration
 
@@ -698,7 +698,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | spec |  | [ClusterRegistrationSpec](#clusterregistrationspec) | false |
 | status |  | [ClusterRegistrationStatus](#clusterregistrationstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationSpec
 
@@ -710,7 +710,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | clientRandom | ClientRandom is a random string that the agent generates. When fleet-controller grants a registration, it creates a registration secret with this string in the name. | string | false |
 | clusterLabels | ClusterLabels are copied to the cluster resource during the registration. | map[string]string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationStatus
 
@@ -721,7 +721,7 @@ ClusterRegistration is used internally by Fleet and should not be used directly.
 | clusterName | ClusterName is only set after the registration is being processed by fleet-controller. | string | false |
 | granted | Granted is set to true, if the request service account is present and its token secret exists. This happens directly before creating the registration secret, roles and rolebindings. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationToken
 
@@ -733,7 +733,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | spec |  | [ClusterRegistrationTokenSpec](#clusterregistrationtokenspec) | false |
 | status |  | [ClusterRegistrationTokenStatus](#clusterregistrationtokenstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenSpec
 
@@ -743,7 +743,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | ----- | ----------- | ------ | -------- |
 | ttl | TTL is the time to live for the token. It is used to calculate the expiration time. If the token expires, it will be deleted. | *metav1.Duration | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ClusterRegistrationTokenStatus
 
@@ -754,7 +754,7 @@ ClusterRegistrationToken is used by agents to register a new cluster.
 | expires | Expires is the time when the token expires. | *metav1.Time | false |
 | secretName | SecretName is the name of the secret containing the token. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### Content
 
@@ -765,7 +765,7 @@ Content is used internally by Fleet and should not be used directly. It contains
 | metadata |  | metav1.ObjectMeta | false |
 | content | Content is a byte array, which contains the manifests of a bundle. The bundle resources are copied into the bundledeployment's content resource, so the downstream agent can deploy them. | []byte | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CommitSpec
 
@@ -777,7 +777,7 @@ CommitSpec specifies how to commit changes to the git repository
 | authorEmail | AuthorEmail gives the email to provide when making a commit | string | true |
 | messageTemplate | MessageTemplate provides a template for the commit message, into which will be interpolated the details of the change made. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### CorrectDrift
 
@@ -789,7 +789,7 @@ CommitSpec specifies how to commit changes to the git repository
 | force | Force helm rollback with --force option will be used if true. This will try to recreate all resources in the release. | bool | false |
 | keepFailHistory | KeepFailHistory keeps track of failed rollbacks in the helm history. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepo
 
@@ -801,7 +801,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | spec |  | [GitRepoSpec](#gitrepospec) | false |
 | status |  | [GitRepoStatus](#gitrepostatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoDisplay
 
@@ -814,7 +814,7 @@ GitRepo describes a git repository that is watched by Fleet. The resource contai
 | message | Message contains the relevant message from the deployment conditions. | string | false |
 | error | Error is true if a message is present. | bool | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResource
 
@@ -835,7 +835,7 @@ GitRepoResource contains metadata about the resources of a bundle.
 | message | Message is the first message from the PerClusterStates. | string | false |
 | perClusterState | PerClusterState is a list of states for each cluster. Derived from the summaries non-ready resources. | \[\][ResourcePerClusterState](#resourceperclusterstate) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoResourceCounts
 
@@ -852,7 +852,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | unknown | Unknown is the number of resources in an unknown state. | int | true |
 | notReady | NotReady is the number of not ready resources. Resources are not ready if they do not match any other state. | int | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoSpec
 
@@ -881,7 +881,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | keepResources | KeepResources specifies if the resources created must be kept after deleting the GitRepo. | bool | false |
 | correctDrift | CorrectDrift specifies how drift correction should work. | *[CorrectDrift](#correctdrift) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoStatus
 
@@ -902,7 +902,7 @@ GitRepoResourceCounts contains the number of resources in each state.
 | resourceErrors | ResourceErrors is a sorted list of errors from the resources. | []string | false |
 | lastSyncedImageScanTime | LastSyncedImageScanTime is the time of the last image scan. | metav1.Time | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitTarget
 
@@ -916,7 +916,7 @@ GitTarget is a cluster or cluster group to deploy to.
 | clusterGroup | ClusterGroup is the name of a cluster group in the same namespace as the clusters. | string | false |
 | clusterGroupSelector | ClusterGroupSelector is a label selector to select cluster groups. | *metav1.LabelSelector | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ResourcePerClusterState
 
@@ -931,7 +931,7 @@ ResourcePerClusterState is generated for each non-ready resource of the bundles.
 | patch | Patch for modified resources. | *GenericMap | false |
 | clusterId | ClusterID is the id of the cluster. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### GitRepoRestriction
 
@@ -947,7 +947,7 @@ GitRepoRestriction is a resource that can optionally be used to restrict the opt
 | allowedClientSecretNames | AllowedClientSecretNames is a list of client secret names that GitRepos are allowed to use. | []string | false |
 | allowedTargetNamespaces | AllowedTargetNamespaces restricts TargetNamespace to the given namespaces. If AllowedTargetNamespaces is set, TargetNamespace must be set. | []string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### AlphabeticalPolicy
 
@@ -957,7 +957,7 @@ AlphabeticalPolicy specifies a alphabetical ordering policy.
 | ----- | ----------- | ------ | -------- |
 | order | Order specifies the sorting order of the tags. Given the letters of the alphabet as tags, ascending order would select Z, and descending order would select A. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImagePolicyChoice
 
@@ -968,7 +968,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | semver | SemVer gives a semantic version range to check against the tags available. | *[SemVerPolicy](#semverpolicy) | false |
 | alphabetical | Alphabetical set of rules to use for alphabetical ordering of the tags. | *[AlphabeticalPolicy](#alphabeticalpolicy) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScan
 
@@ -980,7 +980,7 @@ ImagePolicyChoice is a union of all the types of policy that can be supplied.
 | spec |  | [ImageScanSpec](#imagescanspec) | false |
 | status |  | [ImageScanStatus](#imagescanstatus) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanSpec
 
@@ -996,7 +996,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | suspend | This flag tells the controller to suspend subsequent image scans. It does not apply to already started scans. Defaults to false. | bool | false |
 | policy | Policy gives the particulars of the policy to be followed in selecting the most recent image | [ImagePolicyChoice](#imagepolicychoice) | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanStatus
 
@@ -1012,7 +1012,7 @@ API is taken from https://github.com/fluxcd/image-reflector-controller
 | observedGeneration |  | int64 | false |
 | canonicalImageName | CanonicalName is the name of the image repository with all the implied bits made explicit; e.g., `docker.io/library/alpine` rather than `alpine`. | string | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### SemVerPolicy
 
@@ -1022,7 +1022,7 @@ SemVerPolicy specifies a semantic version policy.
 | ----- | ----------- | ------ | -------- |
 | range | Range gives a semver range for the image tag; the highest version within the range that's a tag yields the latest image. | string | true |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### FleetYAML
 
@@ -1037,7 +1037,7 @@ FleetYAML is the top-level structure of the fleet.yaml file. The fleet.yaml file
 | imageScans | ImageScans are optional and used to update container image references in the git repo. | \[\][ImageScanYAML](#imagescanyaml) | false |
 | overrideTargets | OverrideTargets overrides targets that are defined in the GitRepo resource. If overrideTargets is provided the bundle will not inherit targets from the GitRepo. | \[\][GitTarget](#gittarget) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)
 
 #### ImageScanYAML
 
@@ -1048,4 +1048,4 @@ ImageScanYAML is a single entry in the ImageScan list from fleet.yaml.
 | name | Name of the image scan. Unused. | string | false |
 | ImageScanSpec |  | [ImageScanSpec](#imagescanspec) | false |
 
-[Back to Custom Resources](#custom-resources-spec)
+[Back to Custom Resources](#)


### PR DESCRIPTION
This fixes:
* building issues for 0.13, with images linked with outdated relative paths
* out-of-maintenance banners, which are not yet needed for 0.12 and 0.13
* broken links and anchors across all versions

Our CI, through `yarn build`, would previously only warn about broken links and anchors, which would then be easily missed.
This updates Docusaurus config to throw errors instead, making them fail CI, to enable them to be fixed as early as possible.