### PR TITLE
Document globbing support for Helm secret name per path

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -212,7 +212,31 @@ Fleet allows you to define unique credentials for each Helm chart path in a Git 
 If `gitRepo.spec.helmSecretNameForPaths` is defined, `gitRepo.spec.helmSecretName` is ignored.
 :::
 
-Create a file named `secrets-path.yaml` that specifies credentials for each path in your `GitRepo`. The keys must match the full path to a bundle directory (a folder containing a `fleet.yaml file`), which may have more segments than the entry under `paths:`. If a path listed in the GitRepo is not included in this file, Fleet does not use credentials for it.
+Create a file named `secrets-path.yaml` that specifies credentials for each path in your `GitRepo`. Each key can be either:
+- an exact path, in which case it must match the full path to a bundle directory (a folder containing a `fleet.yaml
+file`), which may have more segments than the entry under `paths:`.
+- a _glob_ matching one or more paths, useful when credentials need to be reused across multiple paths/bundles.
+[Here](https://pkg.go.dev/path/filepath#Match) are examples of supported syntax.
+:::info
+If more than one glob match a given path in a git repository, then Fleet will order globs lexically and use credentials
+from the first match.
+
+_Example_: For repository path `world-domination/ui_charts` and a secret containing the following keys, credentials
+under the _second_ glob will be used:
+```yaml
+world-domination/*_charts: # will not be used
+  username: fleet-ci
+  password: foo
+  insecureSkipVerify: true
+world-domination/*: # will be used, as `/*` will be sorted before `/*_charts`
+  username: fleet-ci
+  password: foo
+  insecureSkipVerify: true
+```
+:::
+
+If a path listed in the GitRepo is not included in this file, whether through exact paths or glob matching, then Fleet
+does not use credentials for it.
 
 :::note
 The file should be named `secrets-path.yaml`, otherwise Fleet will not be able to use it.


### PR DESCRIPTION
A GitRepo's `spec.helmSecretNameForPaths` now supports globbing in the referenced secret's keys.

Refers to https://github.com/rancher/fleet/issues/3398.