### PR TITLE
Document semver and polling support for OCI-based HelmOps

### DIFF
--- a/docs/helm-ops.md
+++ b/docs/helm-ops.md
@@ -81,7 +81,7 @@ bundle will be created, aborting deployment.
 A Helm chart can also be referenced through its repository and chart name, with an optional version, which may be a
 static version or a version constraint.
 
-This is where polling can make sense, because referencing the chart using a repository allows Fleet to check the
+In this case, polling can make sense, because referencing the chart using a repository allows Fleet to check the
 repository's `index.yaml` for available versions matching the `version` field.
 
 Example:
@@ -114,6 +114,8 @@ and no bundle being created.
 In this case, Fleet will be downloading OCI artifacts. This means that:
 * the `version` field represents an OCI artifact's tag, which may be different to the actual version of the
 chart stored in the OCI artifact.
+* polling is supported: Fleet can check available OCI tags matching both the provided repository and version constraint
+on a regular basis, configured through the polling interval.
 * an OCI artifact may contain multiple Helm charts. This use case has only been validated with OCI artifacts containing
   a single Helm chart.
 :::

--- a/versioned_docs/version-0.13/helm-ops.md
+++ b/versioned_docs/version-0.13/helm-ops.md
@@ -81,7 +81,7 @@ bundle will be created, aborting deployment.
 A Helm chart can also be referenced through its repository and chart name, with an optional version, which may be a
 static version or a version constraint.
 
-This is where polling can make sense, because referencing the chart using a repository allows Fleet to check the
+In this case, polling can make sense, because referencing the chart using a repository allows Fleet to check the
 repository's `index.yaml` for available versions matching the `version` field.
 
 Example:
@@ -114,6 +114,8 @@ and no bundle being created.
 In this case, Fleet will be downloading OCI artifacts. This means that:
 * the `version` field represents an OCI artifact's tag, which may be different to the actual version of the
 chart stored in the OCI artifact.
+* polling is supported: Fleet can check available OCI tags matching both the provided repository and version constraint
+on a regular basis, configured through the polling interval.
 * an OCI artifact may contain multiple Helm charts. This use case has only been validated with OCI artifacts containing
   a single Helm chart.
 :::


### PR DESCRIPTION
This support is now visible in documentation for v0.14 and v0.13, where it has recently been added.