### PR TITLE
Fix warnings about strict host key checks

### DIFF
--- a/docs/gitrepo-add.md
+++ b/docs/gitrepo-add.md
@@ -88,14 +88,6 @@ The key has to be in PEM format.
 
 ### Known hosts
 
-:::warning
-
-If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o
-stricthostkeychecking=yes` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
-`false`.
-
-:::
-
 Fleet supports injecting `known_hosts` into an SSH secret. Here is an example of how to add it:
 
 Fetch the public key hash (taking Github as an example)

--- a/versioned_docs/version-0.10/gitrepo-add.md
+++ b/versioned_docs/version-0.10/gitrepo-add.md
@@ -85,7 +85,7 @@ The key has to be in PEM format.
 :::warning
 
 If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o
-stricthostkeychecking=yes` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
+stricthostkeychecking=no` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
 `false`.
 
 :::

--- a/versioned_docs/version-0.11/gitrepo-add.md
+++ b/versioned_docs/version-0.11/gitrepo-add.md
@@ -85,7 +85,7 @@ The key has to be in PEM format.
 :::warning
 
 If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o
-stricthostkeychecking=yes` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
+stricthostkeychecking=no` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
 `false`.
 
 :::

--- a/versioned_docs/version-0.12/gitrepo-add.md
+++ b/versioned_docs/version-0.12/gitrepo-add.md
@@ -86,7 +86,7 @@ The key has to be in PEM format.
 :::warning
 
 If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o
-stricthostkeychecking=yes` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
+stricthostkeychecking=no` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
 `false`.
 
 :::

--- a/versioned_docs/version-0.13/gitrepo-add.md
+++ b/versioned_docs/version-0.13/gitrepo-add.md
@@ -83,14 +83,6 @@ The key has to be in PEM format.
 
 ### Known hosts
 
-:::warning
-
-If you don't add one or more public keys into the secret, any server's public key will be trusted and added. (`ssh -o
-stricthostkeychecking=yes` will be used), unless you install Fleet with chart value `insecureSkipHostKeyChecks` set to
-`false`.
-
-:::
-
 Fleet supports injecting `known_hosts` into an SSH secret. Here is an example of how to add it:
 
 Fetch the public key hash (taking Github as an example)


### PR DESCRIPTION
This rephrases misleading warnings about known hosts, removing them entirely for versions where the default behaviour is secure.