### PR TITLE
Disable scheduled updatecli workflow runs

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -3,9 +3,9 @@ name: "Updatecli"
 
 on:
   workflow_dispatch:
-  schedule:
+  #schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '0 * * * *'
+    #- cron: '0 * * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
This repository will be archived soon; the new source of truth for Fleet documentation should be `rancher/fleet-product-docs` [1].

[1]: https://github.com/rancher/fleet-product-docs